### PR TITLE
feat (engine base classes): Add engine base

### DIFF
--- a/include/engine/core/engine.h
+++ b/include/engine/core/engine.h
@@ -1,11 +1,16 @@
 #pragma once
+#include <memory>
 
-#ifndef ENGINE_CORE_ENGINE_H
-#define ENGINE_CORE_ENGINE_H
+#include <engine/core/serviceContainer.h>
 
 class Engine {
+private:
+    Engine();
 public:
-    Engine(); // Temporary
-};
+    static Engine& instance() {
+        static Engine engine {};
+        return engine;
+    }
 
-#endif // ENGINE_CORE_ENGINE_H
+    const std::unique_ptr<ServiceContainer> services;
+};

--- a/include/engine/core/iEngineService.h
+++ b/include/engine/core/iEngineService.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <concepts>
+
+class IEngineService {
+public:
+    virtual ~IEngineService() = default;
+};
+
+template<typename T>
+concept EngineService = std::derived_from<T, IEngineService>;

--- a/include/engine/core/serviceContainer.h
+++ b/include/engine/core/serviceContainer.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <memory>
+#include <optional>
+#include <typeindex>
+#include <unordered_map>
+
+#include <engine/core/iEngineService.h>
+
+class ServiceContainer final {
+public:
+
+    ServiceContainer();
+
+    template<typename T, typename... Args>
+        requires EngineService<T>
+    T& registerService(Args&&... args) {
+        auto service = std::make_unique<T>(std::forward<Args>(args)...);
+        T& ref = *service;
+        services_[std::type_index(typeid(T))] = std::move(service);
+        return ref;
+    }
+
+    template<typename T>
+        requires EngineService<T>
+    void unregisterService() {
+        services_.erase(std::type_index(typeid(T)));
+    }
+
+    template<typename T>
+    requires EngineService<T>
+    std::reference_wrapper<T> getService() const {
+        const auto it = services_.find(std::type_index(typeid(T)));
+        if (it == services_.end()) {
+            throw std::runtime_error("Service not found");
+        }
+        // So we get an EngineServiceBase, but we know it's actually a T. We do not use dynamic cast because we are not storing subtypes of T
+        return std::ref(*static_cast<T*>(it->second.get()));
+    }
+
+    template <typename T>
+        requires EngineService<T>
+    std::optional<std::reference_wrapper<T>> tryGetService() const {
+        const auto it = services_.find(std::type_index(typeid(T)));
+        if (it == services_.end()) {
+            return std::nullopt;
+        }
+
+        return std::ref(*static_cast<T*>(it->second.get()));
+    }
+
+private:
+    std::unordered_map<std::type_index, std::unique_ptr<IEngineService>> services_;
+};

--- a/include/engine/core/serviceContainer.h
+++ b/include/engine/core/serviceContainer.h
@@ -31,7 +31,7 @@ public:
     std::reference_wrapper<T> getService() const {
         const auto it = services_.find(std::type_index(typeid(T)));
         if (it == services_.end()) {
-            throw std::runtime_error("Service not found");
+            throw std::runtime_error("Service not found: " + std::string(typeid(T).name()));
         }
         // So we get an EngineServiceBase, but we know it's actually a T. We do not use dynamic cast because we are not storing subtypes of T
         return std::ref(*static_cast<T*>(it->second.get()));

--- a/include/engine/public/component.h
+++ b/include/engine/public/component.h
@@ -9,13 +9,17 @@
  * If it is not used for the same reason, make the naming more specific to avoid confusion.
  * I could not tell what it was for, so I left it out for now.
  */
-class Component : public GameObject {
+class Component {
 private:
-    std::weak_ptr<GameObject> _parent;
+    std::optional<std::reference_wrapper<GameObject>> parent_;
+    bool active_ = true;
     // TODO: Maybe add the active property back with a more specific name if needed.
 public:
-    explicit Component(const Scene& scene);
-    ~Component() override = default;
+    explicit Component(GameObject& parent);
+    virtual ~Component() = default;
+
+    [[nodiscard]] bool active() const noexcept;
+    Component& active(bool value) noexcept;
 
     virtual void update() = 0;
     virtual void onAttach() = 0;

--- a/include/engine/public/component.h
+++ b/include/engine/public/component.h
@@ -1,7 +1,8 @@
 #pragma once
 #include <memory>
+#include <optional>
 
-#include <engine/public/gameObject.h>
+class GameObject;
 
 /**
  * @brief Base class for all components that can be attached to GameObjects.
@@ -29,4 +30,4 @@ public:
 };
 
 template<typename T>
-    concept IsComponent = std::is_base_of<Component, T>::value;
+    concept IsComponent = std::is_base_of_v<Component, T>;

--- a/include/engine/public/component.h
+++ b/include/engine/public/component.h
@@ -25,4 +25,4 @@ public:
 };
 
 template<typename T>
-    concept IsComponent = std::is_base_of<Component, T>::type;
+    concept IsComponent = std::is_base_of<Component, T>::value;

--- a/include/engine/public/component.h
+++ b/include/engine/public/component.h
@@ -4,17 +4,10 @@
 
 class GameObject;
 
-/**
- * @brief Base class for all components that can be attached to GameObjects.
- * I left out the active: bool property because the GameObject already has an active property.
- * If it is not used for the same reason, make the naming more specific to avoid confusion.
- * I could not tell what it was for, so I left it out for now.
- */
 class Component {
 private:
     std::optional<std::reference_wrapper<GameObject>> parent_;
     bool active_ = true;
-    // TODO: Maybe add the active property back with a more specific name if needed.
 public:
     explicit Component(GameObject& parent);
     virtual ~Component() = default;
@@ -23,10 +16,10 @@ public:
     Component& active(bool value) noexcept;
 
     virtual void update() = 0;
-    virtual void onAttach() = 0;
-    virtual void onDetach() = 0;
-    virtual void onSerialize() = 0;
-    virtual void onDeserialize() = 0;
+    virtual void on_attach() = 0;
+    virtual void on_detach() = 0;
+    virtual void on_serialize() = 0;
+    virtual void on_deserialize() = 0;
 };
 
 template<typename T>

--- a/include/engine/public/component.h
+++ b/include/engine/public/component.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <memory>
+
+#include <engine/public/gameObject.h>
+
+/**
+ * @brief Base class for all components that can be attached to GameObjects.
+ * I left out the active: bool property because the GameObject already has an active property.
+ * If it is not used for the same reason, make the naming more specific to avoid confusion.
+ * I could not tell what it was for, so I left it out for now.
+ */
+class Component : public GameObject {
+private:
+    std::weak_ptr<GameObject> _parent;
+    // TODO: Maybe add the active property back with a more specific name if needed.
+public:
+    explicit Component(const Scene& scene);
+    ~Component() override = default;
+
+    virtual void update() = 0;
+    virtual void onAttach() = 0;
+    virtual void onDetach() = 0;
+    virtual void onSerialize() = 0;
+    virtual void onDeserialize() = 0;
+};
+
+template<typename T>
+    concept IsComponent = std::is_base_of<Component, T>::type;

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -51,7 +51,7 @@ public:
     std::optional<std::reference_wrapper<T>> getComponent() const noexcept {
         for (auto& component : components_) {
             if (auto& casted = dynamic_cast<T*>(component.get())) {
-                return std::ref(casted);
+                return std::ref(*casted);
             }
         }
         return std::nullopt;

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -60,7 +60,7 @@ public:
     template<IsComponent T>
     std::optional<std::reference_wrapper<T>> get_component() const noexcept {
         for (auto& component : components_) {
-            if (auto& casted = dynamic_cast<T*>(component.get())) {
+            if (auto* casted = dynamic_cast<T*>(component.get())) {
                 return std::ref(*casted);
             }
         }

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -1,0 +1,112 @@
+#pragma once
+#include <algorithm>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <vector>
+
+#include "component.h"
+#include "scene.h"
+#include "transform.h"
+
+class GameObject {
+private:
+    /** GameObject owns its components.
+    Alternative: Make it shared so multiple objects can share components.
+    It would be nice if you want to do complex shared behaviors but its complex, don't. */
+    std::vector<std::unique_ptr<Component>> components_ {};
+
+    /** GameObject does not own its children. Why? Because every GameObject instance is owned by a scene.
+        If you turn this around, a Scene would only own root objects. That works, but it isn't what we
+        want to happen. A shared_ptr would also not work because you would get weird undefined behaviors.
+        In this case its paramount that a GameObject is destroyed with the intention to keep its
+        children alive, or to have them be destroyed all together on destruction. */
+    std::vector<std::weak_ptr<GameObject>> children_ {};
+
+    std::optional<std::reference_wrapper<GameObject>> parent_;
+    bool isActive_ {true};
+
+public:
+    // TODO: Could we for the love of god make some of these immutable and private? I do not know if these have to be public or mutable right now...
+    std::string name;
+    std::string tag;
+    int layer {};
+    Scene& scene;
+    Transform transform;
+
+    explicit GameObject(const Scene& scene);
+    virtual ~GameObject();
+
+    [[nodiscard]] bool isActiveInWorld() const noexcept;
+    [[nodiscard]] bool isActive() const noexcept;
+
+    GameObject& parent(GameObject& parent);
+    GameObject& parent(std::nullopt_t);
+
+    std::vector<std::weak_ptr<GameObject>>& children();
+    GameObject& addChild(const std::shared_ptr<GameObject>& child);
+    GameObject& removeChild(GameObject& child);
+
+    template<IsComponent T>
+    std::optional<std::reference_wrapper<T>> getComponent() const noexcept {
+        for (auto& component : components_) {
+            if (auto& casted = dynamic_cast<T*>(component.get())) {
+                return std::ref(casted);
+            }
+        }
+        return std::nullopt;
+    }
+
+    /** Get all components of type T attached to this GameObject.
+        Note that it does NOT include the components attached to the
+        child objects. Those can be retrieved with GameObject::getComponentsInChildren */
+    template<IsComponent T>
+    std::vector<std::weak_ptr<T>> getComponents() const {
+        auto filtered = components_
+            | std::views::filter([](auto& c) { return dynamic_cast<T*>(c.get()); })
+            | std::views::transform([](auto& c) -> std::reference_wrapper<T> {
+                return std::ref(*static_cast<T*>(c.get()));
+            });
+
+        return std::vector<std::weak_ptr<T>>(filtered.begin(), filtered.end());
+    }
+
+    template<IsComponent T>
+    std::vector<std::reference_wrapper<T>> getComponentsFromChildren() const {
+        std::vector<std::reference_wrapper<T>> result {};
+
+        for (auto& childWeak : children_) {
+            if (const auto child = childWeak.lock()) {
+                auto childComponents = child->getComponentsFromChildren<T>();
+                result.insert(result.end(), childComponents.begin(), childComponents.end());
+            }
+        }
+
+        return result;
+    }
+
+    template<IsComponent T, typename... Args>
+    T& addComponent(Args&&... args) {
+        auto component = std::make_unique<T>(std::forward<Args>(args)...);
+        T& ref = *component;
+        components_.emplace_back(std::move(component));
+        return ref;
+    }
+
+    template<IsComponent T>
+    void removeComponent(T& component) {
+        components_.erase(
+            std::remove_if(
+                components_.begin(),
+                components_.end(),
+                [&component](const std::unique_ptr<Component>& c) {
+                    return c.get() == &component;
+                }
+            ),
+            components_.end()
+        );
+    }
+
+    void serialize() const;
+    void deserialize() const;
+};

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -27,26 +27,42 @@ private:
     bool isActive_ {true};
     bool isActiveInWorld_ {true};
 
+    std::string name_;
+    std::string tag_;
+    int layer_ {};
+    Scene& scene_;
+    Transform transform_;
+
 public:
     // TODO: Could we for the love of god make some of these immutable and private? I do not know if these have to be public or mutable right now...
-    std::string name;
-    std::string tag;
-    int layer {};
-    Scene& scene;
-    Transform transform;
 
     explicit GameObject(Scene& scene);
     virtual ~GameObject();
 
+    GameObject& parent(GameObject& parent);
+    GameObject& parent(std::nullopt_t);
+
     [[nodiscard]] bool isActiveInWorld() const noexcept;
     [[nodiscard]] bool isActive() const noexcept;
+
     void setInactive() noexcept;
     void setActive() noexcept;
     void setActiveInWorld() noexcept;
     void setInactiveInWorld() noexcept;
 
-    GameObject& parent(GameObject& parent);
-    GameObject& parent(std::nullopt_t);
+    GameObject& name(const std::string& name);
+    [[nodiscard]] const std::string& name() const;
+
+    GameObject& tag(std::string& tag);
+    [[nodiscard]] const std::string& tag() const;
+
+    GameObject& layer(int layer);
+    [[nodiscard]] int layer() const;
+
+    GameObject& transform(Transform transform);
+    [[nodiscard]] Transform& transform();
+
+    const Scene& scene() const noexcept;
 
     std::vector<std::reference_wrapper<GameObject>>& children();
     GameObject& addChild(GameObject& child);

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -34,7 +34,7 @@ public:
     Scene& scene;
     Transform transform;
 
-    explicit GameObject(const Scene& scene);
+    explicit GameObject(Scene& scene);
     virtual ~GameObject();
 
     [[nodiscard]] bool isActiveInWorld() const noexcept;
@@ -61,14 +61,14 @@ public:
         Note that it does NOT include the components attached to the
         child objects. Those can be retrieved with GameObject::getComponentsInChildren */
     template<IsComponent T>
-    std::vector<std::weak_ptr<T>> getComponents() const {
+    std::vector<std::reference_wrapper<T>> getComponents() const {
         auto filtered = components_
             | std::views::filter([](auto& c) { return dynamic_cast<T*>(c.get()); })
             | std::views::transform([](auto& c) -> std::reference_wrapper<T> {
                 return std::ref(*static_cast<T*>(c.get()));
             });
 
-        return std::vector<std::weak_ptr<T>>(filtered.begin(), filtered.end());
+        return std::vector<std::reference_wrapper<T>>(filtered.begin(), filtered.end());
     }
 
     template<IsComponent T>

--- a/include/engine/public/scene.h
+++ b/include/engine/public/scene.h
@@ -1,0 +1,5 @@
+#pragma once
+
+class Scene {
+
+};

--- a/include/engine/public/transform.h
+++ b/include/engine/public/transform.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <memory>
+#include <optional>
+
+#include "util/vector3.h"
+
+class Transform {
+private:
+    Vector3 position_;
+    float rotation_{};
+    int scale_{};
+    std::optional<std::reference_wrapper<Transform>> parent_;
+public:
+
+    Transform();
+    explicit Transform(Vector3 position);
+    Transform(Vector3 position, float rotation, int scale);
+    Transform(Vector3 position, float rotation, int scale, std::optional<std::reference_wrapper<Transform>> parent);
+
+    Transform& position(const Vector3& pos) noexcept;
+    [[nodiscard]] Vector3 position() const noexcept;
+
+    Transform& rotation(float rot) noexcept;
+    [[nodiscard]] float rotation() const noexcept;
+
+    Transform& scale(int scale) noexcept;
+    [[nodiscard]] int scale() const noexcept;
+
+    Transform& parent(Transform& parent) noexcept;
+    [[nodiscard]] std::optional<std::reference_wrapper<Transform>> parent() const noexcept;
+};

--- a/include/engine/public/transform.h
+++ b/include/engine/public/transform.h
@@ -17,9 +17,9 @@ public:
     Transform(Vector3 position, float rotation, int scale);
     Transform(Vector3 position, float rotation, int scale, std::optional<std::reference_wrapper<Transform>> parent);
 
-    Transform& relativePosition(const Vector3& pos) noexcept;
-    [[nodiscard]] Vector3 relativePosition() const noexcept;
-    [[nodiscard]] Vector3 absolutePosition() const noexcept;
+    Transform& relative_position(const Vector3& pos) noexcept;
+    [[nodiscard]] Vector3 relative_position() const noexcept;
+    [[nodiscard]] Vector3 absolute_position() const noexcept;
 
     Transform& rotation(float rot) noexcept;
     [[nodiscard]] float rotation() const noexcept;

--- a/include/engine/public/transform.h
+++ b/include/engine/public/transform.h
@@ -17,8 +17,9 @@ public:
     Transform(Vector3 position, float rotation, int scale);
     Transform(Vector3 position, float rotation, int scale, std::optional<std::reference_wrapper<Transform>> parent);
 
-    Transform& position(const Vector3& pos) noexcept;
-    [[nodiscard]] Vector3 position() const noexcept;
+    Transform& relativePosition(const Vector3& pos) noexcept;
+    [[nodiscard]] Vector3 relativePosition() const noexcept;
+    [[nodiscard]] Vector3 absolutePosition() const noexcept;
 
     Transform& rotation(float rot) noexcept;
     [[nodiscard]] float rotation() const noexcept;
@@ -26,6 +27,6 @@ public:
     Transform& scale(int scale) noexcept;
     [[nodiscard]] int scale() const noexcept;
 
-    Transform& parent(Transform& parent) noexcept;
+    Transform& parent(std::optional<std::reference_wrapper<Transform>> parent) noexcept;
     [[nodiscard]] std::optional<std::reference_wrapper<Transform>> parent() const noexcept;
 };

--- a/include/engine/public/transform.h
+++ b/include/engine/public/transform.h
@@ -2,7 +2,7 @@
 #include <memory>
 #include <optional>
 
-#include "util/vector3.h"
+#include <engine/public/util/vector3.h>
 
 class Transform {
 private:

--- a/include/engine/public/util/point.h
+++ b/include/engine/public/util/point.h
@@ -1,0 +1,8 @@
+#pragma once
+class Point {
+public:
+    Point();
+    Point(float x, float y);
+    float x;
+    float y;
+};

--- a/include/engine/public/util/vector3.h
+++ b/include/engine/public/util/vector3.h
@@ -6,4 +6,10 @@ public:
     float x;
     float y;
     float z;
+
+    Vector3 operator+(const Vector3& right) const noexcept;
+    Vector3 operator-(const Vector3& right) const noexcept;
+
+    Vector3& operator+=(const Vector3&& right) noexcept;
+    Vector3 operator-=(const Vector3&& right) noexcept;
 };

--- a/include/engine/public/util/vector3.h
+++ b/include/engine/public/util/vector3.h
@@ -1,0 +1,9 @@
+#pragma once
+class Vector3 {
+public:
+    Vector3();
+    Vector3(float x, float y, float z);
+    float x;
+    float y;
+    float z;
+};

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,6 +1,4 @@
 #include <engine/core/engine.h>
-#include <iostream>
 
-Engine::Engine() {
-    std::cout << "Engine created" << std::endl; // Temporary
-}
+Engine::Engine() :
+    services(std::make_unique<ServiceContainer>()) {}

--- a/src/core/serviceContainer.cpp
+++ b/src/core/serviceContainer.cpp
@@ -1,0 +1,3 @@
+#include <engine/core/serviceContainer.h>
+
+ServiceContainer::ServiceContainer() : services_() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <engine/core/engine.h>
 
 int main() {
-    Engine engine;
     return 0;
 }

--- a/src/public/component.cpp
+++ b/src/public/component.cpp
@@ -1,4 +1,5 @@
 #include <engine/public/component.h>
+#include <engine/public/gameObject.h>
 
 Component::Component(GameObject& parent)
     : parent_(std::ref(parent)), active_(true) {}

--- a/src/public/component.cpp
+++ b/src/public/component.cpp
@@ -8,7 +8,7 @@ bool Component::active() const noexcept {
     return active_;
 }
 
-Component& Component::active(bool value) noexcept {
+Component& Component::active(const bool value) noexcept {
     active_ = value;
     return *this;
 }

--- a/src/public/component.cpp
+++ b/src/public/component.cpp
@@ -1,0 +1,3 @@
+#include <engine/public/component.h>
+
+Component::Component(const Scene& scene) : GameObject(scene) {}

--- a/src/public/component.cpp
+++ b/src/public/component.cpp
@@ -1,3 +1,13 @@
 #include <engine/public/component.h>
 
-Component::Component(const Scene& scene) : GameObject(scene) {}
+Component::Component(GameObject& parent)
+    : parent_(std::ref(parent)), active_(true) {}
+
+bool Component::active() const noexcept {
+    return active_;
+}
+
+Component& Component::active(bool value) noexcept {
+    active_ = value;
+    return *this;
+}

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -1,11 +1,47 @@
 #include <engine/public/gameObject.h>
 #include <engine/public/component.h>
 
-GameObject::GameObject(Scene& scene) : scene(scene) {}
+GameObject::GameObject(Scene& scene) : scene_(scene) {}
 GameObject::~GameObject() {
     if (parent_.has_value()) {
         parent_->get().removeChild(*this);
     }
+}
+
+GameObject& GameObject::name(const std::string& name) {
+    name_ = name;
+    return *this;
+}
+const std::string& GameObject::name() const {
+    return name_;
+}
+
+GameObject& GameObject::tag(std::string& tag) {
+    tag_ = tag;
+    return *this;
+}
+const std::string& GameObject::tag() const {
+    return tag_;
+}
+
+GameObject& GameObject::layer(int layer) {
+    layer_ = layer;
+    return *this;
+}
+int GameObject::layer() const {
+    return layer_;
+}
+
+GameObject& GameObject::transform(Transform transform) {
+    transform_ = transform;
+    return *this;
+}
+Transform& GameObject::transform() {
+    return transform_;
+}
+
+const Scene& GameObject::scene() const noexcept {
+    return scene_;
 }
 
 void GameObject::setInactive() noexcept {

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -1,0 +1,70 @@
+#include <engine/public/gameObject.h>
+#include <engine/public/component.h>
+
+GameObject::GameObject(const Scene &scene) : scene(const_cast<Scene&>(scene)) {}
+GameObject::~GameObject() {
+    if (parent_.has_value()) {
+        parent_->get().removeChild(*this);
+    }
+}
+
+
+// TODO: Discuss whether this should be recursive (i.e., check parents' active states)
+// TODO: Discuss if a GameObject its active state should be determined by its parent
+bool GameObject::isActiveInWorld() const noexcept {
+    if (parent_.has_value()) {
+        return parent_->get().isActiveInWorld() && isActive_;
+    }
+    return isActive_;
+}
+
+// TODO: Discuss whether this should be recursive (i.e., check parents' active states)
+// TODO: Discuss if a GameObject its active state should be determined by its parent
+bool GameObject::isActive() const noexcept {
+    return isActive_;
+}
+
+GameObject& GameObject::parent(GameObject& parent) {
+    parent_ = parent;
+    return *this;
+}
+
+GameObject& GameObject::parent(std::nullopt_t) {
+    if (!parent_.has_value()) {
+        return *this;
+    }
+
+    parent_ = std::nullopt;
+    return *this;
+}
+
+std::vector<std::weak_ptr<GameObject>>& GameObject::children() {
+    return children_;
+}
+
+GameObject& GameObject::addChild(const std::shared_ptr<GameObject>& child) {
+    children_.push_back(child);
+    child->parent(*this);
+    return *this;
+}
+
+GameObject& GameObject::removeChild(GameObject& child) {
+    std::erase_if(
+        children_,
+        [&child](const std::weak_ptr<GameObject>& ptr) {
+            if (const auto locked = ptr.lock()) {
+                return locked.get() == &child;
+            }
+            return false;
+        }
+    );
+    child.parent(std::nullopt);
+    return *this;
+}
+
+void GameObject::serialize() const {
+    throw std::runtime_error("Not implemented");
+}
+void GameObject::deserialize() const {
+    throw std::runtime_error("Not implemented");
+}

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -1,7 +1,7 @@
 #include <engine/public/gameObject.h>
 #include <engine/public/component.h>
 
-GameObject::GameObject(const Scene &scene) : scene(const_cast<Scene&>(scene)) {}
+GameObject::GameObject(Scene &scene) : scene(scene) {}
 GameObject::~GameObject() {
     if (parent_.has_value()) {
         parent_->get().removeChild(*this);

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -4,7 +4,7 @@
 GameObject::GameObject(Scene& scene) : scene_(scene) {}
 GameObject::~GameObject() {
     if (parent_.has_value()) {
-        parent_->get().removeChild(*this);
+        parent_->get().remove_child(*this);
     }
 }
 
@@ -16,7 +16,7 @@ const std::string& GameObject::name() const {
     return name_;
 }
 
-GameObject& GameObject::tag(std::string& tag) {
+GameObject& GameObject::tag(const std::string& tag) {
     tag_ = tag;
     return *this;
 }
@@ -24,7 +24,7 @@ const std::string& GameObject::tag() const {
     return tag_;
 }
 
-GameObject& GameObject::layer(int layer) {
+GameObject& GameObject::layer(const int layer) {
     layer_ = layer;
     return *this;
 }
@@ -44,25 +44,25 @@ const Scene& GameObject::scene() const noexcept {
     return scene_;
 }
 
-void GameObject::setInactive() noexcept {
-    isActive_ = false;
+void GameObject::set_inactive() noexcept {
+    is_active_ = false;
 }
-void GameObject::setActive() noexcept {
-    isActive_ = true;
+void GameObject::set_active() noexcept {
+    is_active_ = true;
 }
-void GameObject::setActiveInWorld() noexcept {
-    isActiveInWorld_ = true;
+void GameObject::set_active_in_world() noexcept {
+    is_active_in_world_ = true;
 }
-void GameObject::setInactiveInWorld() noexcept {
-    isActiveInWorld_ = false;
-}
-
-bool GameObject::isActiveInWorld() const noexcept {
-    return isActiveInWorld_;
+void GameObject::set_inactive_in_world() noexcept {
+    is_active_in_world_ = false;
 }
 
-bool GameObject::isActive() const noexcept {
-    return isActive_;
+bool GameObject::is_active_in_world() const noexcept {
+    return is_active_in_world_;
+}
+
+bool GameObject::is_active() const noexcept {
+    return is_active_;
 }
 
 GameObject& GameObject::parent(GameObject& parent) {
@@ -83,12 +83,12 @@ std::vector<std::reference_wrapper<GameObject>>& GameObject::children() {
     return children_;
 }
 
-GameObject& GameObject::addChild(GameObject& child) {
+GameObject& GameObject::add_child(GameObject& child) {
     children_.emplace_back(child);
     return *this;
 }
 
-GameObject& GameObject::removeChild(GameObject& child) {
+GameObject& GameObject::remove_child(GameObject& child) {
     std::erase_if(children_, [&](auto& ref) {
         return &ref.get() == &child;
     });

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -1,7 +1,7 @@
 #include <engine/public/gameObject.h>
 #include <engine/public/component.h>
 
-GameObject::GameObject(Scene &scene) : scene(scene) {}
+GameObject::GameObject(Scene& scene) : scene(scene) {}
 GameObject::~GameObject() {
     if (parent_.has_value()) {
         parent_->get().removeChild(*this);

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -1,0 +1,1 @@
+#include <engine/public/scene.h>

--- a/src/public/transform.cpp
+++ b/src/public/transform.cpp
@@ -1,0 +1,52 @@
+#include <engine/public/transform.h>
+
+Transform::Transform()
+    : Transform(Vector3(0.0f, 0.0f, 0.0f), 0.0f, 1) {}
+
+Transform::Transform(const Vector3 position)
+    : Transform(position, 0.0f, 1) {}
+
+Transform::Transform(const Vector3 position, const float rotation, const int scale)
+    : Transform(position, rotation, scale, std::nullopt) {}
+
+Transform::Transform(const Vector3 position, const float rotation, const int scale, std::optional<std::reference_wrapper<Transform>> parent)
+    : position_(position), rotation_(rotation), scale_(scale), parent_(parent){}
+
+Transform& Transform::position(const Vector3& pos) noexcept {
+    position_ = pos;
+    return *this;
+}
+
+Vector3 Transform::position() const noexcept {
+    return position_;
+}
+
+Transform& Transform::rotation(const float rot) noexcept {
+    rotation_ = rot;
+    return *this;
+}
+
+float Transform::rotation() const noexcept {
+    return rotation_;
+}
+
+Transform& Transform::scale(const int scale) noexcept {
+    scale_ = scale;
+    return *this;
+}
+
+int Transform::scale() const noexcept {
+    return scale_;
+}
+
+Transform& Transform::parent(Transform& parent) noexcept {
+    parent_.emplace(std::ref(parent));
+    return *this;
+}
+
+std::optional<std::reference_wrapper<Transform>> Transform::parent() const noexcept {
+    if (parent_) {
+        return parent_->get();
+    }
+    return std::nullopt;
+}

--- a/src/public/transform.cpp
+++ b/src/public/transform.cpp
@@ -12,13 +12,21 @@ Transform::Transform(const Vector3 position, const float rotation, const int sca
 Transform::Transform(const Vector3 position, const float rotation, const int scale, std::optional<std::reference_wrapper<Transform>> parent)
     : position_(position), rotation_(rotation), scale_(scale), parent_(parent){}
 
-Transform& Transform::position(const Vector3& pos) noexcept {
+Transform& Transform::relativePosition(const Vector3& pos) noexcept {
     position_ = pos;
     return *this;
 }
 
-Vector3 Transform::position() const noexcept {
+Vector3 Transform::relativePosition() const noexcept {
     return position_;
+}
+
+Vector3 Transform::absolutePosition() const noexcept {
+    if (!parent_.has_value()) {
+        return position_;
+    }
+    const auto& parentPos = parent_.value().get().absolutePosition();
+    return position_ + parentPos;
 }
 
 Transform& Transform::rotation(const float rot) noexcept {
@@ -39,8 +47,8 @@ int Transform::scale() const noexcept {
     return scale_;
 }
 
-Transform& Transform::parent(Transform& parent) noexcept {
-    parent_.emplace(std::ref(parent));
+Transform& Transform::parent(const std::optional<std::reference_wrapper<Transform>> parent) noexcept {
+    parent_ = parent;
     return *this;
 }
 

--- a/src/public/transform.cpp
+++ b/src/public/transform.cpp
@@ -12,20 +12,20 @@ Transform::Transform(const Vector3 position, const float rotation, const int sca
 Transform::Transform(const Vector3 position, const float rotation, const int scale, std::optional<std::reference_wrapper<Transform>> parent)
     : position_(position), rotation_(rotation), scale_(scale), parent_(parent){}
 
-Transform& Transform::relativePosition(const Vector3& pos) noexcept {
+Transform& Transform::relative_position(const Vector3& pos) noexcept {
     position_ = pos;
     return *this;
 }
 
-Vector3 Transform::relativePosition() const noexcept {
+Vector3 Transform::relative_position() const noexcept {
     return position_;
 }
 
-Vector3 Transform::absolutePosition() const noexcept {
+Vector3 Transform::absolute_position() const noexcept {
     if (!parent_.has_value()) {
         return position_;
     }
-    const auto& parentPos = parent_.value().get().absolutePosition();
+    const auto& parentPos = parent_.value().get().absolute_position();
     return position_ + parentPos;
 }
 

--- a/src/public/util/point.cpp
+++ b/src/public/util/point.cpp
@@ -1,0 +1,4 @@
+#include <engine/public/util/point.h>
+
+Point::Point() : x(0.0f), y(0.0f) {}
+Point::Point(const float x, const float y) : x(x), y(y) {}

--- a/src/public/util/vector3.cpp
+++ b/src/public/util/vector3.cpp
@@ -2,3 +2,25 @@
 
 Vector3::Vector3() : x(0.0f), y(0.0f), z(0.0f) {}
 Vector3::Vector3(const float x, const float y, const float z) : x(x), y(y), z(z) {}
+
+Vector3 Vector3::operator+(const Vector3& right) const noexcept {
+    return {x + right.x, y + right.y, z + right.z};
+}
+Vector3 Vector3::operator-(const Vector3& right) const noexcept {
+    return {x - right.x, y - right.y, z - right.z};
+}
+
+Vector3& Vector3::operator+=(const Vector3&& right) noexcept {
+    x += right.x;
+    y += right.y;
+    z += right.z;
+
+    return *this;
+}
+Vector3 Vector3::operator-=(const Vector3&& right) noexcept {
+    x = x - right.x;
+    y = y - right.y;
+    z = z - right.z;
+
+    return *this;
+}

--- a/src/public/util/vector3.cpp
+++ b/src/public/util/vector3.cpp
@@ -1,0 +1,4 @@
+#include <engine/public/util/vector3.h>
+
+Vector3::Vector3() : x(0.0f), y(0.0f), z(0.0f) {}
+Vector3::Vector3(const float x, const float y, const float z) : x(x), y(y), z(z) {}


### PR DESCRIPTION
Added:
1. Add ServiceContainer implementation;
2. Add Engine base implementation
3. Add IEngineService implementation
4. Add Point implementation
5. Add Transform implementation
6. Add Vector3 implementation
7. Add Component implementation
8. Add Scene scaffold. Does nothing for now it really is just an empty class
9. Add GameObject base implementation

Changed:
1. A lot of classes implement weak_ptr. Now, that can work from time to time, but we often use it in semantically incorrect ways. Sometimes you will see optional<ref<T>> instead of weak_ptr, this is because it is more correct and nicer to work with in practice.

2. The base UML diagram shows practically nothing on which values HAVE to be mutable and why. Ownership does not show, so I implemented it to the best of my ability and left TODO markers where I was not sure (see gameObject.h).

3. Changed the name of IManager to IEngineService because of the naming. IManager is just way to verbose and abstract.