### PR TITLE
feat (ci-tests): add ci/cd with a basic test example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 name: C++ CI
 on:
-  push:
-    branches:
-      - master
-      - development
-      - '@feat/*'
   pull_request:
     branches:
       - master
@@ -21,13 +16,29 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            cmake g++ clang-tidy \
+            cmake g++ clang-tidy ccache \
             libx11-dev libxext-dev libxrandr-dev libxi-dev \
             libxinerama-dev libxcursor-dev \
             libgl1-mesa-dev libfreetype6-dev \
             libpng-dev libjpeg-dev zlib1g-dev
 
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache
+            ~/.ccache
+            build-asan/_deps
+          key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
+      # Enable ccache for faster rebuilds ⚡
+      - name: Configure compiler cache
+        run: echo 'export PATH="/usr/lib/ccache:$PATH"' >> $GITHUB_ENV
+
       - name: Run clang-tidy
+        continue-on-error: true
         run: |
           cmake -S . -B build-tidy -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           clang-tidy -p build-tidy $(find src include tests -name '*.cpp') --warnings-as-errors=*
@@ -36,6 +47,7 @@ jobs:
         run: |
           cmake -S . -B build-asan \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1" \
             -DENABLE_TESTS=ON \
             -DBUILD_SHARED_LIBS=OFF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: C++ CI
+on:
+  push:
+    branches:
+      - master
+      - 'development/**'
+  pull_request:
+    branches:
+      - master
+      - 'development/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Install build + lint dependencies
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ clang-tidy
+
+      # Step 1: Lint with clang-tidy
+      - name: Run clang-tidy
+        run: |
+            cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            clang-tidy -p build $(find . -name '*.cpp') --warnings-as-errors=*
+            
+      # Step 2: Build with AddressSanitizer enabled
+      - name: Configure (ASan)
+        run: cmake -S . -B build-asan -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1"
+
+      - name: Build (ASan)
+        run: cmake --build build-asan
+
+      # Step 3: Run memory-leak tests (ASan will fail on leak)
+      - name: Run with ASan
+        run: |
+          export ASAN_OPTIONS=detect_leaks=1
+          ctest --test-dir build-asan --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,29 +14,36 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      # Install build + lint dependencies
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ clang-tidy
+          sudo apt-get install -y \
+            cmake g++ clang-tidy \
+            libx11-dev libxext-dev libxrandr-dev libxi-dev \
+            libxinerama-dev libxcursor-dev \
+            libgl1-mesa-dev libfreetype6-dev \
+            libpng-dev libjpeg-dev zlib1g-dev
 
-      # Step 1: Lint with clang-tidy
       - name: Run clang-tidy
         run: |
-            cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-            clang-tidy -p build $(find . -name '*.cpp') --warnings-as-errors=*
+          cmake -S . -B build-tidy -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          clang-tidy -p build-tidy $(find src include tests -name '*.cpp') --warnings-as-errors=*
 
-      # Step 2: Build with AddressSanitizer enabled
       - name: Configure (ASan)
-        run: cmake -S . -B build-asan -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1"
+        run: |
+          cmake -S . -B build-asan \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1" \
+            -DENABLE_TESTS=ON \
+            -DBUILD_SHARED_LIBS=OFF
 
       - name: Build (ASan)
-        run: cmake --build build-asan
+        run: cmake --build build-asan --parallel --target all
 
-      # Step 3: Run memory-leak tests (ASan will fail on leak)
-      - name: Run with ASan
+      - name: Run tests (ASan)
         run: |
           export ASAN_OPTIONS=detect_leaks=1
           ctest --test-dir build-asan --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,13 @@ on:
   push:
     branches:
       - master
-      - 'development/**'
+      - development
+      - '@feat/*'
   pull_request:
     branches:
       - master
-      - 'development/**'
-
+      - development
+      - '@feat/*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +27,7 @@ jobs:
         run: |
             cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
             clang-tidy -p build $(find . -name '*.cpp') --warnings-as-errors=*
-            
+
       # Step 2: Build with AddressSanitizer enabled
       - name: Configure (ASan)
         run: cmake -S . -B build-asan -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,10 @@ set(IMGUI_SOURCES
 # =========================================================
 # Testing
 # =========================================================
-set(BUILD_GMOCK OFF)
-set(BUILD_GTEST ON)
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-set(BUILD_SHARED_LIBS OFF)  # ensure static linking
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
   googletest
@@ -188,15 +188,12 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 # =========================================================
 # Enable testing
 # =========================================================
-enable_testing()
-file(GLOB TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp)
-add_executable(tests ${TEST_SOURCES})
+option(ENABLE_TESTS "Enable building tests" ON)
 
-target_link_libraries(tests
-    PRIVATE
-        engine
-        gtest_main
-)
-
-
-add_test(NAME all_tests COMMAND tests)
+if(ENABLE_TESTS)
+    enable_testing()
+    file(GLOB TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp)
+    add_executable(tests ${TEST_SOURCES})
+    target_link_libraries(tests PRIVATE engine gtest_main)
+    add_test(NAME all_tests COMMAND tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,20 @@ set(IMGUI_SOURCES
 )
 
 # =========================================================
+# Testing
+# =========================================================
+set(BUILD_GMOCK OFF)
+set(BUILD_GTEST ON)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(BUILD_SHARED_LIBS OFF)  # ensure static linking
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/heads/main.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+# =========================================================
 # Sources
 # =========================================================
 file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS src/*.cpp)
@@ -170,3 +184,19 @@ endif()
 # Avoid SDL_main issues
 # =========================================================
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
+
+# =========================================================
+# Enable testing
+# =========================================================
+enable_testing()
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp)
+add_executable(tests ${TEST_SOURCES})
+
+target_link_libraries(tests
+    PRIVATE
+        engine
+        gtest_main
+)
+
+
+add_test(NAME all_tests COMMAND tests)

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+// A simple example function from your project
+TEST(ExampleTest, CanAddNumbers) {
+    auto sum = 2 + 3;
+    EXPECT_EQ(sum, 5);
+}


### PR DESCRIPTION
> [!NOTE]
> This is just the CI/CD pipeline with a very basic (GoogleTest) test that contains no logic. The engine library is linked with the tests files. We might want to discuss if we group the tests under a single command as i do now, or seperate them.
> 
> The reason I decided to use GoogleTests is because its easy, simple and feels familiair to the way we know and have handled Unit tests