### PR TITLE
fix (pipeline): split into full build to development and lightweight build on feats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           export ASAN_OPTIONS=detect_leaks=1
           ctest --test-dir build-asan --output-on-failure
 
-  # Lightweight tests for feat branches
+  # Lightweight tests for @feat branches
   light-test:
     if: startsWith(github.head_ref, '@feat/')
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF
 
       - name: Build tests
-        run: cmake --build build-asan --parallel --target all || echo "Skill issue 🤡"
+        run: cmake --build build --parallel --target all
 
       - name: Run tests
         run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,17 @@
 name: C++ CI
+
 on:
   pull_request:
     branches:
       - master
       - development
       - '@feat/*'
+
 jobs:
-  build:
+  # We only run the full build on master and development branches
+  # The building is simply too expensive to run on every feature branch PR
+  full-build:
+    if: github.base_ref == 'master' || github.base_ref == 'development'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -33,7 +38,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deps-
 
-      # Enable ccache for faster rebuilds ⚡
       - name: Configure compiler cache
         run: echo 'export PATH="/usr/lib/ccache:$PATH"' >> $GITHUB_ENV
 
@@ -54,9 +58,35 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF
 
       - name: Build (ASan)
-        run: cmake --build build-asan --parallel --target all || echo "Skill issue 🤡"
+        run: cmake --build build-asan --parallel --target all
 
       - name: Run tests (ASan)
         run: |
           export ASAN_OPTIONS=detect_leaks=1
           ctest --test-dir build-asan --output-on-failure
+
+  # Lightweight tests for feat branches
+  light-test:
+    if: startsWith(github.head_ref, '@feat/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libgtest-dev
+
+      - name: Configure (fast build)
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_TESTS=ON \
+            -DBUILD_SHARED_LIBS=OFF
+
+      - name: Build tests
+        run: cmake --build build-asan --parallel --target all || echo "Skill issue 🤡"
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
The build got seperated into a full one on major branches, and a smaller one (tests only) on feat branches. The main reason for this is our GitHub action limit... If we keep this up we would actually hit it before the month is over, besides its a small courtesy to build before you make a PR to a feat. Only `development` should be carefully protected