### PR TITLE
feat: add rendering service

### DIFF
--- a/include/engine/core/rendering/renderingService.h
+++ b/include/engine/core/rendering/renderingService.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <engine/core/iEngineService.h>
+#include <engine/core/rendering/renderer.h>
+
+class SDL_Renderer;
+class RenderingService : public IEngineService {
+public:
+    explicit RenderingService(Renderer* renderer);
+    ~RenderingService() override = default;
+    void draw(const std::vector<std::reference_wrapper<GameObject>>& objects);
+
+private:
+    friend class AssetManager;
+    const std::unique_ptr<Renderer> renderer_; // owns SDL_Renderer*
+};

--- a/src/core/rendering/renderingService.cpp
+++ b/src/core/rendering/renderingService.cpp
@@ -1,0 +1,9 @@
+#include <engine/core/rendering/renderingService.h>
+
+RenderingService::RenderingService(Renderer* renderer)
+    : renderer_{renderer}{
+}
+
+void RenderingService::draw(const std::vector<std::reference_wrapper<GameObject>>& objects) {
+    renderer_->render(objects);
+}


### PR DESCRIPTION
Do we want to keep the renderingservice class? All it does is wrap the renderer which wraps SDL and forward a call. I vote we rename the renderer to renderingService and be done with it.