### PR TITLE
feat(input): implement manager

### DIFF
--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -1,0 +1,14 @@
+#include <engine/input/input_manager.h>
+#include <engine/input/i_input_provider.h>
+
+const IInputProvider& InputManager::provider() const
+{
+    if (!provider_)
+        throw std::runtime_error("Input provider is not set.");
+    return *provider_;
+}
+
+void InputManager::set_provider(std::unique_ptr<IInputProvider> provider) noexcept
+{
+    provider_ = std::move(provider);
+}


### PR DESCRIPTION
The signature of the provider's getter is now marked as const. The signature could change depending on the function signatures of SDL's implementation that will be used