### PR TITLE
fix: Make the engine destroyable before the loop ends.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -77,6 +77,10 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.ClassIgnoredRegexp
     value: '^I[A-Z].*'
+  - key: readability-identifier-naming.StaticMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.StaticMemberSuffix
+    value: "_"
 
   # Force explicit constructors
   - key: cppcoreguidelines-explicit-constructors

--- a/include/engine/core/engine.h
+++ b/include/engine/core/engine.h
@@ -1,16 +1,22 @@
 #pragma once
+
 #include <memory>
+#include <iostream>
 
 #include <engine/core/serviceContainer.h>
 
 class Engine {
 private:
+    struct Deleter {
+        void operator()(Engine* e) const { delete e; }
+    };
+
     Engine();
+
+    static std::unique_ptr<Engine, Deleter> engine_instance;
 public:
-    static Engine& instance() {
-        static Engine engine {};
-        return engine;
-    }
+    static Engine& instance();
+    static void quit();
 
     const std::unique_ptr<ServiceContainer> services;
 };

--- a/include/engine/core/engine.h
+++ b/include/engine/core/engine.h
@@ -11,7 +11,7 @@ private:
 
     Engine();
 
-    static std::unique_ptr<Engine, Deleter> engine_instance_;
+    static std::unique_ptr<Engine, Deleter> engine_instance_; // NOLINT(readability-identifier-naming)
 public:
     static Engine& instance();
     static void quit();

--- a/include/engine/core/engine.h
+++ b/include/engine/core/engine.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <iostream>
-
 #include <engine/core/serviceContainer.h>
 
 class Engine {

--- a/include/engine/core/engine.h
+++ b/include/engine/core/engine.h
@@ -11,7 +11,7 @@ private:
 
     Engine();
 
-    static std::unique_ptr<Engine, Deleter> engine_instance;
+    static std::unique_ptr<Engine, Deleter> engine_instance_;
 public:
     static Engine& instance();
     static void quit();

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -7,17 +7,17 @@ Engine::Engine() : services(std::make_unique<ServiceContainer>()) {
 }
 
 Engine& Engine::instance() {
-    if (!engine_instance) {
+    if (!engine_instance_) {
         SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
-        engine_instance = std::unique_ptr<Engine, Deleter>(new Engine());
+        engine_instance_ = std::unique_ptr<Engine, Deleter>(new Engine());
     }
 
-    return *engine_instance;
+    return *engine_instance_;
 }
 
 void Engine::quit() {
-    engine_instance.reset();
+    engine_instance_.reset();
     SDL_Quit();
 }
 
-std::unique_ptr<Engine, Engine::Deleter> Engine::engine_instance = nullptr;
+std::unique_ptr<Engine, Engine::Deleter> Engine::engine_instance_ = nullptr;

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,6 +1,23 @@
 #include <engine/core/engine.h>
 #include <engine/audio/audio_service.h>
+#include <SDL3/SDL.h>
 
 Engine::Engine() : services(std::make_unique<ServiceContainer>()) {
     services->register_service<AudioService>();
 }
+
+Engine& Engine::instance() {
+    if (!engine_instance) {
+        SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
+        engine_instance = std::unique_ptr<Engine, Deleter>(new Engine());
+    }
+
+    return *engine_instance;
+}
+
+void Engine::quit() {
+    engine_instance.reset();
+    SDL_Quit();
+}
+
+std::unique_ptr<Engine, Engine::Deleter> Engine::engine_instance = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <engine/util/memory.h>
+#include <engine/core/engine.h>
 
 // Macro's for tracy based on the CMake option
 namespace {
@@ -13,6 +14,9 @@ namespace {
 
 int main() {
     tracy_init();
+
+    auto& engine = Engine::instance();
+    Engine::quit();
 
     tracy_shutdown();
     return 0;


### PR DESCRIPTION
Due to a goof with static memory and singletons not being nice, we implemented a workaround that should manage the singleton from the instance, not the static class alone.