### PR TITLE
feat(networking): skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ target_include_directories(engine
     PUBLIC 
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     PRIVATE 
+        ${enet_SOURCE_DIR}/include
         ${imgui_SOURCE_DIR} 
         ${imgui_SOURCE_DIR}/backends
 )

--- a/include/engine/network/client.h
+++ b/include/engine/network/client.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+#include <enet/enet.h>
+
+#include <engine/network/router.h>
+
+class Client {
+public:
+    Client(std::shared_ptr<Router> router);
+
+    /* @brief polling network for new messages. */
+    void poll() noexcept;
+
+    /* @brief sending message to host. */
+    void send(Message& message);
+
+    /* @brief Connect to given address. */
+    void connect(std::string address);
+
+    /* @brief Disconnect from current peer. */
+    void disconnect();
+
+    /* @brief Called on connection, setting local uuid and forwarding to custom handlers. */
+    void on_connect() noexcept;
+
+    /* @brief Called on disconnection, cleaning left-over data and forwarding to custom handlers. */
+    void on_disconnect() noexcept;
+
+private:
+    std::shared_ptr<Router> router_{nullptr};
+    std::unique_ptr<ENetPeer> server_peer_{nullptr};
+    std::unique_ptr<ENetHost> client_{nullptr};
+};

--- a/include/engine/network/host.h
+++ b/include/engine/network/host.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <enet/enet.h>
+
+#include <engine/network/router.h>
+
+class Host {
+public:
+    Host(std::shared_ptr<Router> router);
+
+    /* @brief Polling network for new messages. */
+    void poll() noexcept;
+
+    /* @brief Broadcasting message to all clients. */
+    void broadcast(Message& message);
+
+    /* @brief Disconnect all clients. */
+    void disconnect();
+
+    /* @brief Called on new connection with client. Registering new client with new uuid, forwarding it to custom handler and sending uuid to new client. */
+    void on_client_connect() noexcept;
+
+    /* @brief Called on client disconnection. Cleaning data of client and forwarding it to custom handler. */
+    void on_client_disconnect() noexcept;
+
+private:
+    int max_clients_{4};
+    std::shared_ptr<Router> router_{nullptr};
+    std::unordered_map<int, std::unique_ptr<ENetHost>> clients_;
+
+    /* @brief Send message to specific user. Used only to send uuid to register user. */
+    void send(std::string uuid, Message& message);
+};

--- a/include/engine/network/multiplayer_service.h
+++ b/include/engine/network/multiplayer_service.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+
+#include <engine/core/iEngineService.h>
+#include <engine/network/client.h>
+#include <engine/network/host.h>
+#include <engine/network/router.h>
+
+/**
+ * @brief Service containing all functions to properly manage a peer-to-peer connection.
+ *
+ * The service contains delegator methods for all useful functionalities.
+ */
+class MultiplayerService : public IEngineService {
+public:
+    /* @brief Register handler function to message type. */
+    void register_handler(const MessageType type, const std::function<void()>& handler);
+
+    /* @brief Unregister handler of given message type */
+    void unregister_handler(const MessageType type);
+
+    /* @brief Register self as host. */
+    void set_host();
+
+    /* @brief Register self as client. */
+    void set_client();
+
+    /* @brief Poll network for new messages. */
+    void poll();
+
+    /* @brief If client, send to host; If host, broadcast to all clients. */
+    void send(Message& message);
+
+    /* @brief Connect to given address. Only usable as client. */
+    void connect(const std::string& address);
+
+    /* @brief If client, disconnect from host; If host, disconnect all clients. */
+    void disconnect();
+
+private:
+    std::shared_ptr<Router> router_;
+    std::unique_ptr<Client> client_;
+    std::unique_ptr<Host> host_;
+};

--- a/include/engine/network/multiplayer_service.h
+++ b/include/engine/network/multiplayer_service.h
@@ -20,10 +20,10 @@ public:
     /* @brief Unregister handler of given message type */
     void unregister_handler(const MessageType type);
 
-    /* @brief Register self as host. */
+    /* @brief Register self as host (mutually exclusive with client). */
     void set_host();
 
-    /* @brief Register self as client. */
+    /* @brief Register self as client (mutually exclusive with host). */
     void set_client();
 
     /* @brief Poll network for new messages. */

--- a/include/engine/network/network_message.h
+++ b/include/engine/network/network_message.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <variant>
+#include <cstring>
+
+enum class DefaultMessageTypes : uint16_t {
+    CONNECT,
+    DISCONNECT
+};
+
+enum class CustomMessageTypes : uint16_t;
+
+using MessageType = std::variant<DefaultMessageTypes, CustomMessageTypes>;
+
+struct MessageHeader
+{
+    MessageType type;
+    uint32_t size;
+};
+
+struct Message
+{
+    MessageHeader header;
+    std::vector<uint8_t> payload;
+};
+
+// +------ Message Structures ------+
+
+struct MsgConnect
+{
+    char uuid[37];
+};
+
+struct MsgDisconnect
+{
+    char uuid[37];
+};
+
+// +------ Serialization/Deserialization ------+
+template <typename T>
+Message SerializeMessage(const T& data, MessageType type)
+{
+
+}
+
+template <typename T>
+T DeserializeMessage(const Message& message)
+{
+
+}

--- a/include/engine/network/network_state.h
+++ b/include/engine/network/network_state.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <any>
+
+/**
+ * @brief A class containing the current state of all networking objects.
+ *
+ * The class manages the current network state of all networking objects and syncs them
+ * with the other networking peers.
+ */
+class NetworkState {
+public:
+    void set(const std::string& key, const std::any& value) noexcept;
+
+    template<typename T>
+    T get(const std::string& key);
+
+    const bool contains(const std::string& key) const;
+
+    /* @brief Serialize the current network state and return it. */
+    std::string serialize();
+
+    /* @brief Deserialize the new network state and save it. */
+    void deserializer(std::string& data);
+
+private:
+    std::unordered_map<std::string, std::any> data;
+
+    void append_to_buffer();
+};

--- a/include/engine/network/router.h
+++ b/include/engine/network/router.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <unordered_map>
+#include <any>
+#include <string>
+#include <functional>
+
+#include <engine/network/network_message.h>
+
+/**
+ * @brief Router used for sending incoming network messages to corresponding handlers.
+ */
+class Router {
+public:
+    /* @brief Register new handler via given message type. */
+    void register_handler(const MessageType type, const std::function<void()>& handler);
+
+    /* @brief Unregister handler via given message type. */
+    void unregister_handler(const MessageType type);
+
+    /* @brief Route date to handler of given type. */
+    void route(const MessageType type, std::any& data);
+
+private:
+    std::unordered_map<MessageType, std::function<void()>> handlers_;
+};

--- a/include/engine/util/uuid.h
+++ b/include/engine/util/uuid.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <random>
+#include <sstream>
+#include <iomanip>
+#include <array>
+#include <iostream>
+
+namespace uuid {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, 255);
+
+    std::string generate_uuid_v4() {
+
+    }
+}

--- a/src/network/client.cpp
+++ b/src/network/client.cpp
@@ -1,0 +1,36 @@
+#include <engine/network/client.h>
+
+Client::Client(std::shared_ptr<Router> router)
+{
+
+}
+
+void Client::poll() noexcept
+{
+
+}
+
+void Client::send(Message& message)
+{
+
+}
+
+void Client::connect(std::string address)
+{
+
+}
+
+void Client::disconnect()
+{
+
+}
+
+void Client::on_connect() noexcept
+{
+
+}
+
+void Client::on_disconnect() noexcept
+{
+
+}

--- a/src/network/host.cpp
+++ b/src/network/host.cpp
@@ -1,0 +1,36 @@
+#include <engine/network/host.h>
+
+Host::Host(std::shared_ptr<Router> router)
+{
+
+}
+
+void Host::poll() noexcept
+{
+
+}
+
+void Host::broadcast(Message& message)
+{
+
+}
+
+void Host::disconnect()
+{
+
+}
+
+void Host::on_client_connect() noexcept
+{
+
+}
+
+void Host::on_client_disconnect() noexcept
+{
+
+}
+
+void Host::send(std::string uuid, Message& message)
+{
+
+}

--- a/src/network/multiplayer_service.cpp
+++ b/src/network/multiplayer_service.cpp
@@ -1,0 +1,41 @@
+#include <engine/network/multiplayer_service.h>
+
+void MultiplayerService::register_handler(const MessageType type, const std::function<void()>& handler)
+{
+
+}
+
+void MultiplayerService::unregister_handler(const MessageType type)
+{
+
+}
+
+void MultiplayerService::set_host()
+{
+
+}
+
+void MultiplayerService::set_client()
+{
+
+}
+
+void MultiplayerService::poll()
+{
+
+}
+
+void MultiplayerService::send(Message& message)
+{
+
+}
+
+void MultiplayerService::connect(const std::string& address)
+{
+
+}
+
+void MultiplayerService::disconnect()
+{
+
+}

--- a/src/network/network_state.cpp
+++ b/src/network/network_state.cpp
@@ -1,0 +1,32 @@
+#include <engine/network/network_state.h>
+
+void NetworkState::set(const std::string& key, const std::any& value) noexcept
+{
+
+}
+
+template<typename T>
+T NetworkState::get(const std::string& key)
+{
+
+}
+
+const bool NetworkState::contains(const std::string& key) const
+{
+
+}
+
+std::string NetworkState::serialize()
+{
+
+}
+
+void NetworkState::deserializer(std::string& data)
+{
+
+}
+
+void NetworkState::append_to_buffer()
+{
+
+}

--- a/src/network/router.cpp
+++ b/src/network/router.cpp
@@ -1,0 +1,16 @@
+#include <engine/network/router.h>
+
+void Router::register_handler(const MessageType type, const std::function<void()>& handler)
+{
+
+}
+
+void Router::unregister_handler(const MessageType type)
+{
+
+}
+
+void Router::route(const MessageType type, std::any& data)
+{
+
+}


### PR DESCRIPTION
Add a rough skeleton of the networking module. Due to the sheer size and complexity of the networking module, the skeleton is a rough sketch of what the final product will look like. A lot of code requires to be written in order to find out what the best solution is for several problems, which cannot be thought out from the skeleton alone.

Any inconsistencies or missing methods will be added alongside the implementation of the networking module.

Closes #52 