### PR TITLE
update (cmakepresets): with latest default settings and auto copy dll (box2d / catch2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,23 @@ jobs:
             -DENABLE_TESTS=ON \
             -DENABLE_TRACY=OFF \
             -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       
       - name: Run clang-tidy
-        shell: bash
         run: |
-          echo "Running clang-tidy..."
-          clang-tidy -p build \
-            $(find src include -type f \( -name '*.cpp' -o -name '*.h' \) \
+          echo "Collecting files..."
+          mapfile -t FILES < <(
+            find src include -type f -name '*.cpp' \
               ! -path '*/tests/*' \
               ! -path '*/util/memory.cpp' \
-              ! -path '*/iEngineService.*') \
-            --warnings-as-errors=*
-      
+              ! -path '*/iEngineService.*'
+          )
+          echo "Running clang-tidy on ${#FILES[@]} files..."
+          run-clang-tidy -p build -j "$(nproc)" "${FILES[@]}"
+
       - name: Build (ASan)
         shell: bash
         run: cmake --build build --parallel --target all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,20 @@ if(WIN32)
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
     )
 
+    # copy box2d dll if built (located at box2d-build/bin)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${box2d_BINARY_DIR}/bin/libbox2dd.dll"
+            $<TARGET_FILE_DIR:${PROJECT_NAME}>
+    )
+
+    # copy catch2 dll (located at Catch2-build/src)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${Catch2_BINARY_DIR}/src/libCatch2d.dll"
+            $<TARGET_FILE_DIR:${PROJECT_NAME}>
+    )
+
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_CURRENT_SOURCE_DIR}/resources

--- a/CMakeUserPresets.example.json
+++ b/CMakeUserPresets.example.json
@@ -10,6 +10,11 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "c:/msys64/ucrt64/bin/gcc.exe",
         "CMAKE_CXX_COMPILER": "c:/msys64/ucrt64/bin/g++.exe",
+        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_BUILD_TYPE": "Debug",
+        
+        "ENABLE_TRACY": "ON",
+        "ENABLE_TESTS": "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
@@ -22,3 +27,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
A simple update for the CMake config and preset. The config now auto copies .dll for box2d and catch2. The preset is updated with the latest cachevariables. To put it simply, tests and tracy are not loaded unless explicitly noted in the variables.

Also @LarsDevans I tweaked the `CI` linter with some AI this time to speed it up.