### PR TITLE
fix (gameobjects/components): add mark for deletion option

### DIFF
--- a/include/engine/public/component.h
+++ b/include/engine/public/component.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <memory>
 #include <optional>
 
@@ -8,12 +9,17 @@ class Component {
 private:
     std::optional<std::reference_wrapper<GameObject>> parent_;
     bool active_ {true};
+    bool marked_for_deletion_ {false};
+
 public:
     explicit Component();
     virtual ~Component() = default;
 
     [[nodiscard]] bool active() const noexcept;
     Component& active(bool value) noexcept;
+
+    [[nodiscard]] bool marked_for_deletion() const noexcept;
+    Component& mark_for_deletion() noexcept;
 
     virtual void update(float dt) = 0;
     virtual void on_attach() = 0;

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <algorithm>
 #include <optional>
 #include <ranges>
@@ -27,6 +28,8 @@ private:
     Scene& scene_;
     Transform transform_;
 
+    bool marked_for_deletion_ {false};
+
 public:
     explicit GameObject(Scene& scene);
     virtual ~GameObject();
@@ -38,11 +41,14 @@ public:
 
     [[nodiscard]] bool is_active_in_world() const noexcept;
     [[nodiscard]] bool is_active() const noexcept;
-
+    
     void set_inactive() noexcept;
     void set_active() noexcept;
     void set_active_in_world() noexcept;
     void set_inactive_in_world() noexcept;
+    
+    GameObject& mark_for_deletion() noexcept;
+    [[nodiscard]] bool marked_for_deletion() const noexcept;
 
     GameObject& name(const std::string& name);
     [[nodiscard]] const std::string& name() const;

--- a/src/public/component.cpp
+++ b/src/public/component.cpp
@@ -13,6 +13,14 @@ Component& Component::active(const bool value) noexcept {
     return *this;
 }
 
+bool Component::marked_for_deletion() const noexcept {
+    return marked_for_deletion_;
+}
+
+Component& Component::mark_for_deletion() noexcept {
+    marked_for_deletion_ = true;
+}
+
 Component& Component::parent(GameObject& parent) {
     parent_ = std::ref(parent);
     return *this;

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -72,6 +72,14 @@ bool GameObject::is_active() const noexcept {
     return is_active_;
 }
 
+bool GameObject::marked_for_deletion() const noexcept {
+    return marked_for_deletion_;
+}
+
+GameObject& GameObject::mark_for_deletion() noexcept {
+    marked_for_deletion_ = true;
+}
+
 GameObject& GameObject::parent(GameObject& parent) {
     parent_ = parent;
     return *this;


### PR DESCRIPTION
During the creation of the behaviorscript I found that deletion is a bit vague and could cause problems with pointers/references so I took another page from unity and added marks.