### PR TITLE
fix (freetype + physics test): replace freetype with fetch and repair broken test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,26 +36,32 @@ FetchContent_MakeAvailable(SDL3_image)
 # =========================================================
 # FreeType (local package install, sibling folder)
 # =========================================================
-if(NOT TARGET Freetype::Freetype)
-        if(NOT DEFINED FREETYPE_ROOT)
-                set(FREETYPE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../freetype-win-build" CACHE PATH "" FORCE)
-        endif()
-        if(NOT DEFINED FREETYPE_INCLUDE_DIR)
-                set(FREETYPE_INCLUDE_DIR "${FREETYPE_ROOT}/include/freetype2" CACHE PATH "" FORCE)
-        endif()
-        if(NOT DEFINED FREETYPE_LIBRARY)
-                set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib" CACHE FILEPATH "" FORCE)
-        endif()
+if(WIN32)
+        if(NOT TARGET Freetype::Freetype)
+                if(NOT DEFINED FREETYPE_ROOT)
+                        set(FREETYPE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../freetype-win-build" CACHE PATH "" FORCE)
+                endif()
+                if(NOT DEFINED FREETYPE_INCLUDE_DIR)
+                        set(FREETYPE_INCLUDE_DIR "${FREETYPE_ROOT}/include/freetype2" CACHE PATH "" FORCE)
+                endif()
+                if(NOT DEFINED FREETYPE_LIBRARY)
+                        set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib" CACHE FILEPATH "" FORCE)
+                endif()
 
-        add_library(Freetype::Freetype UNKNOWN IMPORTED)
-        set_target_properties(Freetype::Freetype PROPERTIES
-                IMPORTED_LOCATION "${FREETYPE_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIR}"
-        )
+                add_library(Freetype::Freetype UNKNOWN IMPORTED)
+                set_target_properties(Freetype::Freetype PROPERTIES
+                        IMPORTED_LOCATION "${FREETYPE_LIBRARY}"
+                        INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIR}"
+                )
 
-        # Also update legacy variables for find_package compatibility
-        set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}" CACHE PATH "" FORCE)
-        set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}" CACHE FILEPATH "" FORCE)
+                # Also update legacy variables for find_package compatibility
+                set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}" CACHE PATH "" FORCE)
+                set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}" CACHE FILEPATH "" FORCE)
+        endif()
+else()
+    find_package(Freetype REQUIRED)
+    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIRS}") # Provided by find_package
+    set(FREETYPE_LIBRARIES Freetype::Freetype)
 endif()
 # =========================================================
 # SDL3_ttf (needs FreeType)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,26 +36,27 @@ FetchContent_MakeAvailable(SDL3_image)
 # =========================================================
 # FreeType (local package install, sibling folder)
 # =========================================================
-if(WIN32)
-    set(FREETYPE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../freetype-win-build")
-    set(FREETYPE_INCLUDE_DIR "${FREETYPE_ROOT}/include/freetype2")
-    set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib")
-    set(FREETYPE_DLL "${FREETYPE_ROOT}/bin/freetype.dll")
+if(NOT TARGET Freetype::Freetype)
+        if(NOT DEFINED FREETYPE_ROOT)
+                set(FREETYPE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../freetype-win-build" CACHE PATH "" FORCE)
+        endif()
+        if(NOT DEFINED FREETYPE_INCLUDE_DIR)
+                set(FREETYPE_INCLUDE_DIR "${FREETYPE_ROOT}/include/freetype2" CACHE PATH "" FORCE)
+        endif()
+        if(NOT DEFINED FREETYPE_LIBRARY)
+                set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib" CACHE FILEPATH "" FORCE)
+        endif()
 
-    add_library(Freetype::Freetype UNKNOWN IMPORTED)
-    set_target_properties(Freetype::Freetype PROPERTIES
-        IMPORTED_LOCATION "${FREETYPE_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIR}"
-    )
+        add_library(Freetype::Freetype UNKNOWN IMPORTED)
+        set_target_properties(Freetype::Freetype PROPERTIES
+                IMPORTED_LOCATION "${FREETYPE_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIR}"
+        )
 
-    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}")
-    set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}")
-else()
-    find_package(Freetype REQUIRED)
-    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIRS}") # Provided by find_package
-    set(FREETYPE_LIBRARIES Freetype::Freetype)
+        # Also update legacy variables for find_package compatibility
+        set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}" CACHE PATH "" FORCE)
+        set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}" CACHE FILEPATH "" FORCE)
 endif()
-
 # =========================================================
 # SDL3_ttf (needs FreeType)
 # =========================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,30 +36,22 @@ FetchContent_MakeAvailable(SDL3_image)
 # =========================================================
 # FreeType (local package install, sibling folder)
 # =========================================================
-if(WIN32)
-    set(FREETYPE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../freetype-win-build")
-    set(FREETYPE_INCLUDE_DIR "${FREETYPE_ROOT}/include/freetype2")
-    set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib")
-    set(FREETYPE_DLL "${FREETYPE_ROOT}/bin/freetype.dll")
+FetchContent_Declare(
+    freetype
+    GIT_REPOSITORY https://github.com/freetype/freetype.git
+    GIT_TAG master
+)
 
-    add_library(Freetype::Freetype UNKNOWN IMPORTED)
-    set_target_properties(Freetype::Freetype PROPERTIES
-        IMPORTED_LOCATION "${FREETYPE_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIR}"
-    )
+FetchContent_MakeAvailable(freetype)
 
-    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}")
-    set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}")
-else()
-    find_package(Freetype REQUIRED)
-    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIRS}") # Provided by find_package
-    set(FREETYPE_LIBRARIES Freetype::Freetype)
-endif()
+add_library(Freetype::Freetype ALIAS freetype)
+set(FREETYPE_LIBRARY $<TARGET_FILE:freetype>)
+set(FREETYPE_INCLUDE_DIR ${freetype_SOURCE_DIR}/include)
 
 # =========================================================
 # SDL3_ttf (needs FreeType)
 # =========================================================
-set(SDL3TTF_VENDORED OFF)
+set(SDL3TTF_VENDORED OFF)  # use external freetype
 FetchContent_Declare(
         SDL3_ttf
         GIT_REPOSITORY https://github.com/libsdl-org/SDL_ttf.git
@@ -141,7 +133,7 @@ target_link_libraries(engine
         SDL3::SDL3
         SDL3_image::SDL3_image
         SDL3_ttf::SDL3_ttf
-        Freetype::Freetype
+        freetype
         enet 
         box2d
 )
@@ -216,12 +208,6 @@ if(WIN32)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "${Catch2_BINARY_DIR}/src/libCatch2d.dll"
-            $<TARGET_FILE_DIR:${PROJECT_NAME}>
-    )
-
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${FREETYPE_DLL}"
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,22 +36,30 @@ FetchContent_MakeAvailable(SDL3_image)
 # =========================================================
 # FreeType (local package install, sibling folder)
 # =========================================================
-FetchContent_Declare(
-    freetype
-    GIT_REPOSITORY https://github.com/freetype/freetype.git
-    GIT_TAG master
-)
+if(WIN32)
+    set(FREETYPE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../freetype-win-build")
+    set(FREETYPE_INCLUDE_DIR "${FREETYPE_ROOT}/include/freetype2")
+    set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib")
+    set(FREETYPE_DLL "${FREETYPE_ROOT}/bin/freetype.dll")
 
-FetchContent_MakeAvailable(freetype)
+    add_library(Freetype::Freetype UNKNOWN IMPORTED)
+    set_target_properties(Freetype::Freetype PROPERTIES
+        IMPORTED_LOCATION "${FREETYPE_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIR}"
+    )
 
-add_library(Freetype::Freetype ALIAS freetype)
-set(FREETYPE_LIBRARY $<TARGET_FILE:freetype>)
-set(FREETYPE_INCLUDE_DIR ${freetype_SOURCE_DIR}/include)
+    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}")
+    set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}")
+else()
+    find_package(Freetype REQUIRED)
+    set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIRS}") # Provided by find_package
+    set(FREETYPE_LIBRARIES Freetype::Freetype)
+endif()
 
 # =========================================================
 # SDL3_ttf (needs FreeType)
 # =========================================================
-set(SDL3TTF_VENDORED OFF)  # use external freetype
+set(SDL3TTF_VENDORED OFF)
 FetchContent_Declare(
         SDL3_ttf
         GIT_REPOSITORY https://github.com/libsdl-org/SDL_ttf.git
@@ -133,7 +141,7 @@ target_link_libraries(engine
         SDL3::SDL3
         SDL3_image::SDL3_image
         SDL3_ttf::SDL3_ttf
-        freetype
+        Freetype::Freetype
         enet 
         box2d
 )
@@ -208,6 +216,12 @@ if(WIN32)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "${Catch2_BINARY_DIR}/src/libCatch2d.dll"
+            $<TARGET_FILE_DIR:${PROJECT_NAME}>
+    )
+
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${FREETYPE_DLL}"
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
     )
 

--- a/include/engine/public/scene.h
+++ b/include/engine/public/scene.h
@@ -12,7 +12,7 @@ private:
     float time_scale_;
     std::vector<std::unique_ptr<GameObject>> game_objects_;
 
-    Scene(const std::string& name);
+    Scene(std::string name);
 
     using listener_function_t = std::function<void(Scene&)>;
     std::vector<listener_function_t> run_listeners_;
@@ -29,9 +29,9 @@ private:
 public:
     virtual ~Scene();
 
-    void on_run(listener_function_t);
-    void on_stop(listener_function_t);
-    void on_destroy(listener_function_t);
+    void on_run(listener_function_t& listener);
+    void on_stop(listener_function_t& listener);
+    void on_destroy(listener_function_t& listener);
 
     Scene& time_scale(float modifier);
     [[nodiscard]] float time_scale() const;

--- a/include/engine/public/scene_service.h
+++ b/include/engine/public/scene_service.h
@@ -23,6 +23,7 @@ public:
     SceneService& add_scene_and_load(const std::string& name);
     SceneService& remove_scene(const std::string& name);
 
+    [[nodiscard]]
     std::set<std::string> contained_scene_names() const;
 
     [[nodiscard]] std::optional<std::reference_wrapper<Scene>> current_scene() const;

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -5,24 +5,24 @@
 #include <algorithm>
 #include <SDL3/SDL.h>
 
-Scene::Scene(const std::string& name)
-    : is_running_(false), time_scale_(1.0f), game_objects_ {}, name_{name} {
+Scene::Scene(std::string name)
+    : is_running_(false), time_scale_(1.0f), name_{std::move(name)} {
 }
 
 Scene::~Scene() {
     execute_listeners(destroy_listeners_);
 }
 
-void Scene::on_run(listener_function_t func) {
-    run_listeners_.push_back(func);
+void Scene::on_run(listener_function_t& listener) {
+    run_listeners_.push_back(listener);
 }
 
-void Scene::on_stop(listener_function_t func) {
-    stop_listeners_.push_back(func);
+void Scene::on_stop(listener_function_t& listener) {
+    stop_listeners_.push_back(listener);
 }
 
-void Scene::on_destroy(listener_function_t func) {
-    destroy_listeners_.push_back(func);
+void Scene::on_destroy(listener_function_t& listener) {
+    destroy_listeners_.push_back(listener);
 }
 
 void Scene::execute_listeners(const std::vector<Scene::listener_function_t> &listeners) {
@@ -31,14 +31,14 @@ void Scene::execute_listeners(const std::vector<Scene::listener_function_t> &lis
     }
 }
 
-void Scene::game_loop() {
+void Scene::game_loop() { // NOLINT [readability-make-member-function-const]
     constexpr float accumulator_default_value = 0.0f;
     constexpr float fixed_step = 1.0f / 60.0f; // ~60 fps
 
     float accumulator = accumulator_default_value;
 
     Uint64 last = SDL_GetPerformanceCounter();
-    float freq = static_cast<float>(SDL_GetPerformanceFrequency());
+    auto freq = static_cast<float>(SDL_GetPerformanceFrequency());
 
     auto& rendering_service = Engine::instance()
         .services

--- a/src/public/scene_service.cpp
+++ b/src/public/scene_service.cpp
@@ -1,12 +1,8 @@
 #include <engine/public/scene_service.h>
 
-SceneService::SceneService()
-    : scenes_{  } {
-}
-
-SceneService::SceneService(const std::string& name)
-    : scenes_{  } {
-    Scene* scene = new Scene(name);
+SceneService::SceneService() = default;
+SceneService::SceneService(const std::string& name) {
+    auto* scene = new Scene(name);
     scene->run();
     scenes_.try_emplace(name, std::move(std::unique_ptr<Scene>(scene)));
 }
@@ -18,7 +14,7 @@ Scene& SceneService::add_scene(const std::string& name) {
 
     // Scene not found
     if (it == scenes_.end()) {
-        Scene* scene = new Scene(name);
+        auto* scene = new Scene(name);
         scenes_.try_emplace(name, std::move(std::unique_ptr<Scene>(scene)));
         return *scene;
     }

--- a/tests/engine/physics/creation.cpp
+++ b/tests/engine/physics/creation.cpp
@@ -6,7 +6,6 @@
 #include <engine/public/component.h>
 #include <engine/public/gameObject.h>
 #include <engine/public/util/vector3.h>
-#include <engine/public/scene.h>
 #include <engine/public/scene_service.h>
 
 struct DummyGameObject : public GameObject {
@@ -29,7 +28,10 @@ TEST_CASE("physics_creation_factory_creates_body", "[PhysicsCreationFactory]") {
 
     Vector3 position{0.0f, 0.0f, 0.0f};
 
-    DummyScene dummy_scene;
+    const std::string& scene_name = "Test Scene";
+    auto scene_service = SceneService();
+    Scene& dummy_scene = scene_service.add_scene(scene_name);
+    
     DummyGameObject dummy_game_object(dummy_scene);
     DummyComponent dummy_component;
     auto& comp = dummy_component.parent(dummy_game_object);


### PR DESCRIPTION
Upon adding the engine to the game repository I found out that our current freetype setup just does not work. We cannot include a folder as the `../` is always inconsistent. So I figured I'd write overrides for them as I experienced myself how big of a pain it can be to add that otherwise. Currently they can be overriden, which is done in the game repository

Also there was 1 test stil broken and linter errors on main 🤡 Somehow it slipped through the linter?