### PR TITLE
fix (cmake): add copy set of freetype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if(WIN32)
                 if(NOT DEFINED FREETYPE_LIBRARY)
                         set(FREETYPE_LIBRARY "${FREETYPE_ROOT}/lib/freetype.lib" CACHE FILEPATH "" FORCE)
                 endif()
+                set(FREETYPE_DLL "${FREETYPE_ROOT}/bin/freetype.dll")
 
                 add_library(Freetype::Freetype UNKNOWN IMPORTED)
                 set_target_properties(Freetype::Freetype PROPERTIES


### PR DESCRIPTION
So turns out for windows that the copy-ing of dll's expected a set value of the location 🤡 