### PR TITLE
fix (gameobjects): don't load/render when not active

### DIFF
--- a/include/engine/public/scene.h
+++ b/include/engine/public/scene.h
@@ -48,6 +48,8 @@ class Scene {
       const std::string& id) const;
   [[nodiscard]] std::vector<std::reference_wrapper<GameObject>> game_objects()
       const;
+  [[nodiscard]] std::vector<std::reference_wrapper<GameObject>>
+  active_game_objects() const;
 
   template <typename T, typename... Args>
   T& add_game_object(Args&&... args) {

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -56,10 +56,20 @@ void GameObject::set_inactive_in_world() noexcept {
 }
 
 bool GameObject::is_active_in_world() const noexcept {
+  if (parent_.has_value()) {
+    return is_active_in_world_ && parent_->get().is_active_in_world();
+  }
+
   return is_active_in_world_;
 }
 
-bool GameObject::is_active() const noexcept { return is_active_; }
+bool GameObject::is_active() const noexcept {
+  if (parent_.has_value()) {
+    return is_active_ && parent_->get().is_active();
+  }
+
+  return is_active_;
+}
 
 bool GameObject::marked_for_deletion() const noexcept {
   return marked_for_deletion_;

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -76,11 +76,11 @@ void Scene::game_loop() {  // NOLINT [readability-make-member-function-const]
       system_service.update();
     });
 
-    std::map<int, std::multimap<int, std::reference_wrapper<Renderable>>> layered_renderables{};
+    std::map<int, std::multimap<int, std::reference_wrapper<Renderable>>>
+        layered_renderables{};
 
-    auto game_objects = this->game_objects();
+    auto game_objects = this->active_game_objects();
     for (auto game_object_wrapper : game_objects) {
-
       const GameObject& game_object = game_object_wrapper.get();
 
       if (!layered_renderables.contains(game_object.layer())) {
@@ -88,16 +88,13 @@ void Scene::game_loop() {  // NOLINT [readability-make-member-function-const]
         layered_renderables.try_emplace(game_object.layer());
       }
 
-      auto& obj_layer =
-        layered_renderables.at(game_object.layer());
+      auto& obj_layer = layered_renderables.at(game_object.layer());
 
       for (auto component : game_object.get_components<Component>()) {
-
         component.get().update(frame_dt);
         if (auto* const renderable =
                 dynamic_cast<Renderable*>(&component.get());
             component.get().active()) {
-
           obj_layer.emplace(renderable->order_in_layer(), *renderable);
         }
       }
@@ -190,6 +187,19 @@ std::vector<std::reference_wrapper<GameObject>> Scene::game_objects() const {
   refs.reserve(game_objects_.size());
   for (const auto& game_object : game_objects_) {
     refs.emplace_back(*game_object);
+  }
+  return refs;
+}
+
+std::vector<std::reference_wrapper<GameObject>> Scene::active_game_objects()
+    const {
+  std::vector<std::reference_wrapper<GameObject>> refs;
+  refs.reserve(game_objects_.size());
+  for (const auto& game_object : game_objects_) {
+    auto& game_object_ref = *game_object;
+    if (game_object_ref.is_active() && game_object_ref.is_active_in_world()) {
+      refs.emplace_back(*game_object);
+    }
   }
   return refs;
 }


### PR DESCRIPTION
A quick fix to address the issue of rendering/loading gameobjects even when they are not active