### PR TITLE
fix (body2d): update outdated sizing calculation in members

### DIFF
--- a/include/engine/physics/world/body/body_2d.h
+++ b/include/engine/physics/world/body/body_2d.h
@@ -3,6 +3,7 @@
 #include <box2d/box2d.h>
 #include <engine/physics/world/body/body_type_2d.h>
 #include <engine/physics/world/body/shape_type_2d.h>
+#include <engine/public/util/point.h>
 #include <engine/public/util/vector3.h>
 
 #include <vector>
@@ -79,14 +80,15 @@ struct Body2D {
    * @param body The Body2D instance to set the size for.
    * @param size The new size as a Vector3.
    */
-  static void set_body_size(const Body2D& body, const Vector3& size);
+  static void set_body_size(const Body2D& body, const Vector3& size,
+                            Point offset);
 
   /** @brief Sets the radius of the specified body.
    *
    * @param body The Body2D instance to set the radius for.
    * @param radius The new radius value.
    */
-  static void set_body_radius(const Body2D& body, float radius);
+  static void set_body_radius(const Body2D& body, float radius, Point offset);
 
   /** @brief Sets the bounciness of the specified body for a given shape type.
    *

--- a/src/physics/world/body/body_2d.cpp
+++ b/src/physics/world/body/body_2d.cpp
@@ -58,28 +58,39 @@ void Body2D::set_body_type(const Body2D& body, BodyType2D::Type type) {
   b2Body_SetType(body.id, b2_type);
 }
 
-void Body2D::set_body_size(const Body2D& body, const Vector3& size) {
+void Body2D::set_body_size(const Body2D& body, const Vector3& size,
+                           Point offset) {
+  float width_m = PhysicsMath::pixels_to_box2d(size.x);
+  float height_m = PhysicsMath::pixels_to_box2d(size.y);
+
+  float half_width = width_m / default_box_divisor;
+  float half_height = height_m / default_box_divisor;
+
+  b2Vec2 converted_offset = {
+      PhysicsMath::pixels_to_box2d(offset.x + size.x * 0.5f),
+      PhysicsMath::pixels_to_box2d(offset.y + size.y * 0.5f)};
+
   for (const auto& shape : body.shapes) {
     if (shape.type != b2ShapeType::b2_polygonShape) {
       continue;
     }
 
-    b2Polygon box =
-        b2MakeBox(size.x / default_box_divisor, size.y / default_box_divisor);
+    b2Polygon box = b2MakeOffsetBox(half_width, half_height, converted_offset,
+                                    b2MakeRot(0.0f));
     b2Shape_SetPolygon(shape.id, &box);
   }
 }
 
-void Body2D::set_body_radius(const Body2D& body, float radius) {
+void Body2D::set_body_radius(const Body2D& body, float radius, Point offset) {
   for (const auto& shape : body.shapes) {
     if (shape.type != b2ShapeType::b2_circleShape) {
       continue;
     }
 
     b2Circle circle;
-
-    circle.center = b2Vec2{0.0f, 0.0f};
-    circle.radius = radius;
+    circle.radius = PhysicsMath::pixels_to_box2d(radius);
+    circle.center = b2Vec2{PhysicsMath::pixels_to_box2d(offset.x),
+                           PhysicsMath::pixels_to_box2d(offset.y)};
 
     b2Shape_SetCircle(shape.id, &circle);
   }

--- a/src/public/components/colliders/box_collider_2d.cpp
+++ b/src/public/components/colliders/box_collider_2d.cpp
@@ -57,7 +57,7 @@ BoxCollider2D& BoxCollider2D::width(float value) noexcept {
   width_ = value;
 
   auto& rigidbody = get_rigidbody().get();
-  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f});
+  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f}, offset());
 
   return *this;
 }
@@ -68,7 +68,7 @@ BoxCollider2D& BoxCollider2D::height(float value) noexcept {
   height_ = value;
 
   auto& rigidbody = get_rigidbody().get();
-  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f});
+  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f}, offset());
 
   return *this;
 }

--- a/src/public/components/colliders/circle_collider_2d.cpp
+++ b/src/public/components/colliders/circle_collider_2d.cpp
@@ -54,6 +54,10 @@ float CircleCollider2D::radius() const noexcept { return radius_; }
 
 CircleCollider2D& CircleCollider2D::radius(float value) noexcept {
   radius_ = value;
+
+  auto& rigidbody = get_rigidbody().get();
+  Body2D::set_body_radius(rigidbody.body(), radius_, offset());
+
   return *this;
 }
 


### PR DESCRIPTION
A small fix for the physics calculation in bod2D size members. Originally we had no conversion from pixel to box2D meters. I added this in a later PR. Now we must convert units before setting/getting metric values. This PR fixes that we set old low values.

I tested this myself using a behavior, it works as expected but shortens towards the top and not bottom so you'd need to counter it with an offset.

```cpp
auto box_collider_opt = get_component<BoxCollider2D>();

if (box_collider_opt.has_value()) {
  auto& box_collider = box_collider_opt->get();
  if (provider.is_key_held(KeyCode::c)) {
    box_collider.height(8.0f);  // crouch height
  } 
  else {
    box_collider.height(16.0f);  // normal height
  }
}
```