### PR TITLE
refactor(go): allow scene manipulation from go

### DIFF
--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -75,7 +75,7 @@ class GameObject {
   [[nodiscard]] Transform& transform();
   [[nodiscard]] const Transform& transform() const;
 
-  [[nodiscard]] const Scene& scene() const noexcept;
+  [[nodiscard]] Scene& scene() const noexcept;
   void scene(Scene& scene) noexcept;
 
   [[nodiscard]] std::vector<std::reference_wrapper<GameObject>>& children();

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -44,7 +44,7 @@ Transform& GameObject::transform() { return transform_; }
 
 const Transform& GameObject::transform() const { return transform_; }
 
-const Scene& GameObject::scene() const noexcept { return scene_; }
+Scene& GameObject::scene() const noexcept { return scene_; }
 
 void GameObject::scene(Scene& scene) noexcept { scene_ = scene; }
 


### PR DESCRIPTION
While working on the game I was required to do some manipulative operations on the scene. However, this is disallowed by the current setup