### PR TITLE
feat (behavior): add documentation and fix on_awake not having access to parent

### DIFF
--- a/include/engine/public/behavior.h
+++ b/include/engine/public/behavior.h
@@ -8,32 +8,68 @@
 #include <stdexcept>
 
 /**
- * @brief Base class for defining behaviors that can be attached to Components.
- * @note This class is inteded to be inherited from to create specific
- * behaviors.
+ * @brief Base class for defining logic that can be attached to Components,
+ *        similar to Unity's MonoBehaviour.
  *
- * The Behavior class provides a structured way to define lifecycle methods
- * for game logic, such as initialization, updates, and destruction.
- * It also offers utility methods to interact with the associated GameObject
- * and its Components.
+ * Behaviors provide a structured lifecycle for game logic:
+ * - on_awake()   : Called once when the Component is created.
+ * - on_start()   : Called once before the first update.
+ * - on_update()  : Called every frame.
+ * - on_destroy() : Called when the Behavior or its GameObject is destroyed.
+ *
+ * A Behavior operates on the Component it is attached to and provides utility
+ * methods for accessing the GameObject, Transform, and other Components. See it
+ * as a gateway to implement game logic that interacts with the engine's
+ * objects.
+ *
+ * @note Users should derive from this class to implement custom behavior.
+ * @warning on_update() must be overridden.
  */
 class Behavior {
  public:
   Behavior();
   virtual ~Behavior() = default;
 
+  /**
+   * @brief Attaches this Behavior to a Component.
+   * @param component The component this behavior should operate on.
+   * @throws std::runtime_error if already attached.
+   */
   void attach(Component& component);
 
+  /// Called when the Component is created. Runs before on_start().
   virtual void on_awake(){};
+
+  /// Called before the first frame on_update().
   virtual void on_start(){};
+
+  /**
+   * @brief Called once per frame.
+   * @param dt Time delta since last frame.
+   */
   virtual void on_update(float dt) = 0;
+
+  /// Called when the Behavior or associated GameObject is destroyed.
   virtual void on_destroy(){};
 
+  /**
+   * @return Reference to the GameObject this Behavior operates on.
+   * @throws std::runtime_error if not attached.
+   */
   [[nodiscard]] GameObject& game_object() const;
+
+  /**
+   * @return Reference to the Transform of the attached GameObject.
+   */
   [[nodiscard]] Transform& transform() const;
 
+  /// @return Whether the behavior is currently enabled.
   [[nodiscard]] bool enabled() const;
+
+  /// Enables the behavior.
   Behavior& enable();
+
+  /// Disables the behavior.
   Behavior& disable();
 
   template <typename T>
@@ -117,8 +153,13 @@ class Behavior {
     return result;
   }
 
+  /// Destroy the parent game object
   void destroy();
+
+  /// Destroy a specific component on the parent game object
   void destroy(Component& component);
+
+  /// Destroy a specific game object in the scene
   void destroy(GameObject& game_object);
 
  private:

--- a/include/engine/public/components/behaviorscript.h
+++ b/include/engine/public/components/behaviorscript.h
@@ -6,19 +6,24 @@
 #include <memory>
 
 /**
- * @brief A Component that wraps a Behavior, allowing it to be attached to
- * GameObjects.
+ * @brief Component that hosts a Behavior.
  *
  * This class acts as a bridge between the Behavior system and the Component
  * system, enabling Behaviors to be used as Components within the engine's
  * architecture.
+ *
+ * @note Users typically do not interact with this class directly. Instead,
+ *       they create custom Behaviors and attach them to GameObjects via
+ *       Components.
+ * @see Behavior
  */
 class BehaviorScript : public Component {
  public:
   BehaviorScript(std::unique_ptr<Behavior> behavior);
-  ~BehaviorScript() override;
 
+  void on_attach() override;
   void update(float dt) override;
+  void on_detach() override;
 
   void on_serialize() override;
   void on_deserialize() override;

--- a/src/public/components/behaviorscript.cpp
+++ b/src/public/components/behaviorscript.cpp
@@ -7,19 +7,14 @@ BehaviorScript::BehaviorScript(std::unique_ptr<Behavior> behavior)
   if (!behavior_) {
     throw std::runtime_error("BehaviorScript has no associated Behavior.");
   }
+}
+
+void BehaviorScript::on_attach() {
+  Component::on_attach();
 
   behavior_->attach(*this);
   behavior_->enable();
   behavior_->on_awake();
-}
-
-BehaviorScript::~BehaviorScript() {
-  if (!behavior_) {
-    return;
-  }
-
-  behavior_->disable();
-  behavior_->on_destroy();
 }
 
 void BehaviorScript::update(float dt) {
@@ -30,6 +25,17 @@ void BehaviorScript::update(float dt) {
   }
 
   behavior_->on_update(dt);
+}
+
+void BehaviorScript::on_detach() {
+  Component::on_detach();
+
+  if (!behavior_) {
+    return;
+  }
+
+  behavior_->disable();
+  behavior_->on_destroy();
 }
 
 void BehaviorScript::on_serialize() {


### PR DESCRIPTION
In the last days I heard mutiple people saying that behaviors could use some more documentation and that `on_awake` does not behave like it does on unity. This was due to it being called in the constructor instead of `on_attach`. This should now be fixed and have a clearer explanation of what each function does.

We can't really test behavior so I tested it with my own little character behavior which worked fine.