### PR TITLE
feat (physics): collision registration fix + raycast returns hit object

### DIFF
--- a/include/engine/physics/raycast/collider_ray_result.h
+++ b/include/engine/physics/raycast/collider_ray_result.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <box2d/box2d.h>
+#include <engine/public/gameObject.h>
 #include <engine/public/util/point.h>
 
 /**
@@ -11,6 +12,7 @@
  */
 struct ColliderRayResult {
   b2ShapeId shape_id{};
+  std::optional<std::reference_wrapper<GameObject>> game_object{std::nullopt};
   float fraction{0.0f};
   bool is_valid{false};
 

--- a/include/engine/public/components/colliders/collider_2d.h
+++ b/include/engine/public/components/colliders/collider_2d.h
@@ -40,14 +40,10 @@ class Collider2D : public Renderable {
    * enter events.
    * @param other The other collider that entered the trigger.
    */
-  virtual void on_trigger_enter(Collider2D& other);
-  /**
-   * @brief Called when another collider exits this collider's trigger area.
-   * @note This method can be overridden to implement custom behavior on trigger
-   * exit events.
-   * @param other The other collider that exited the trigger.
-   */
-  virtual void on_trigger_exit(Collider2D& other);
+  void on_trigger_enter(Collider2D& other);
+  size_t add_on_trigger_enter(
+      const std::function<void(Collider2D&, Collider2D&)>& action);
+  void remove_on_trigger_enter(int index);
 
   /**
    * @brief Called when another collider exits this collider's trigger area.
@@ -55,14 +51,31 @@ class Collider2D : public Renderable {
    * exit events.
    * @param other The other collider that exited the trigger.
    */
-  virtual void on_collision_enter(Collider2D& other);
+  void on_trigger_exit(Collider2D& other);
+  size_t add_on_trigger_exit(
+      const std::function<void(Collider2D&, Collider2D&)>& action);
+  void remove_on_trigger_exit(int index);
   /**
    * @brief Called when another collider exits this collider's trigger area.
    * @note This method can be overridden to implement custom behavior on trigger
    * exit events.
    * @param other The other collider that exited the trigger.
    */
-  virtual void on_collision_exit(Collider2D& other);
+  void on_collision_enter(Collider2D& other);
+  size_t add_on_collision_enter(
+      const std::function<void(Collider2D&, Collider2D&)>& action);
+  void remove_on_collision_enter(int index);
+
+  /**
+   * @brief Called when another collider exits this collider's trigger area.
+   * @note This method can be overridden to implement custom behavior on trigger
+   * exit events.
+   * @param other The other collider that exited the trigger.
+   */
+  void on_collision_exit(Collider2D& other);
+  size_t add_on_collision_exit(
+      const std::function<void(Collider2D&, Collider2D&)>& action);
+  void remove_on_collision_exit(int index);
 
   /**
    * @brief Calculate the distance to another collider.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <engine/util/memory.h>
 
-
 // Macro's for tracy based on the CMake option
 namespace {
 #ifdef TRACY_ENABLE

--- a/src/physics/raycast/physics_raycaster.cpp
+++ b/src/physics/raycast/physics_raycaster.cpp
@@ -19,6 +19,13 @@ ColliderRayResult PhysicsRaycaster::raycast_closest(const b2Vec2& origin,
   ColliderRayResult collision_result;
   if (ray.hit) {
     collision_result.shape_id = ray.shapeId;
+
+    b2BodyId body = b2Shape_GetBody(ray.shapeId);
+    auto* comp = static_cast<Component*>(b2Body_GetUserData(body));
+    if (comp != nullptr && comp->parent().has_value()) {
+      collision_result.game_object = comp->parent()->get();
+    }
+
     collision_result.fraction = ray.fraction;
     collision_result.is_valid = true;
 
@@ -44,6 +51,7 @@ std::vector<ColliderRayResult> PhysicsRaycaster::raycast_all(
 
     b2RayResult result{};
     result.shapeId = shape_id;
+
     result.point = point;
     result.normal = normal;
     result.fraction = fraction;
@@ -65,6 +73,13 @@ std::vector<ColliderRayResult> PhysicsRaycaster::raycast_all(
   for (const auto& ray : results) {
     ColliderRayResult collision_result;
     collision_result.shape_id = ray.shapeId;
+
+    b2BodyId body = b2Shape_GetBody(ray.shapeId);
+    auto* comp = static_cast<Component*>(b2Body_GetUserData(body));
+    if (comp != nullptr && comp->parent().has_value()) {
+      collision_result.game_object = comp->parent()->get();
+    }
+
     collision_result.fraction = ray.fraction;
     collision_result.is_valid = true;
 
@@ -103,6 +118,13 @@ ColliderRayResult PhysicsRaycaster::raycast_segment(const b2Vec2& start,
   ColliderRayResult collision_result;
   if (ray.hit) {
     collision_result.shape_id = ray.shapeId;
+
+    b2BodyId body = b2Shape_GetBody(ray.shapeId);
+    auto* comp = static_cast<Component*>(b2Body_GetUserData(body));
+    if (comp != nullptr && comp->parent().has_value()) {
+      collision_result.game_object = comp->parent()->get();
+    }
+
     collision_result.fraction = ray.fraction;
     collision_result.is_valid = true;
 

--- a/src/physics/world/physics_world.cpp
+++ b/src/physics/world/physics_world.cpp
@@ -36,6 +36,7 @@ void PhysicsWorld::check_collision(
       continue;
     }
 
+    // Get the bodies associated with the shapes
     b2BodyId body_a = b2Shape_GetBody(touch_event->shapeIdA);
     b2BodyId body_b = b2Shape_GetBody(touch_event->shapeIdB);
     auto* comp_a = static_cast<Component*>(b2Body_GetUserData(body_a));
@@ -64,6 +65,7 @@ void PhysicsWorld::check_collision(
             }
           }
 
+          // Check for the collider type currently in the loop
           b2ShapeType collider_shape_type;
           if (auto box = dynamic_cast<BoxCollider2D*>(&collider)) {
             collider_shape_type = b2ShapeType::b2_polygonShape;

--- a/src/physics/world/physics_world.cpp
+++ b/src/physics/world/physics_world.cpp
@@ -1,5 +1,7 @@
 #include <engine/physics/physics_math.h>
 #include <engine/physics/world/physics_world.h>
+#include <engine/public/components/colliders/box_collider_2d.h>
+#include <engine/public/components/colliders/circle_collider_2d.h>
 #include <engine/public/components/colliders/collider_2d.h>
 #include <engine/public/gameObject.h>
 
@@ -39,29 +41,67 @@ void PhysicsWorld::check_collision(
     auto* comp_a = static_cast<Component*>(b2Body_GetUserData(body_a));
     auto* comp_b = static_cast<Component*>(b2Body_GetUserData(body_b));
 
-    auto find_collider_in_objects = [&](Component* comp)
+    auto find_collider_in_objects = [&](Component* comp, b2ShapeId shape_id)
         -> std::optional<std::reference_wrapper<Collider2D>> {
       for (const auto& obj_ref : objects) {
         GameObject& obj = obj_ref.get();
         auto collider_opt = obj.get_component<Collider2D>();
-        if (collider_opt.has_value()) {
-          Collider2D& collider = collider_opt->get();
+        auto collider_opts = obj.get_components<Collider2D>();
 
-          if (&collider == comp) {
+        for (auto& collider_opt : collider_opts) {
+          Collider2D& collider = collider_opt.get();
+
+          auto shapes = collider.get_rigidbody().get().body().shapes;
+          bool shape_found = false;
+          b2ShapeType shape_type;
+
+          for (const auto& shape : shapes) {
+            if (shape.id.index1 == shape_id.index1 &&
+                shape.id.generation == shape_id.generation) {
+              shape_found = true;
+              shape_type = shape.type;
+              break;
+            }
+          }
+
+          b2ShapeType collider_shape_type;
+          if (auto box = dynamic_cast<BoxCollider2D*>(&collider)) {
+            collider_shape_type = b2ShapeType::b2_polygonShape;
+          } else if (auto circle = dynamic_cast<CircleCollider2D*>(&collider)) {
+            collider_shape_type = b2ShapeType::b2_circleShape;
+          } else {
+            return std::nullopt;
+          }
+
+          if (collider.parent()->get().id() == comp->parent()->get().id() &&
+              collider_shape_type == shape_type && shape_found) {
             return std::ref(collider);
           }
         }
       }
+
       return std::nullopt;
     };
 
-    auto collider_a_opt = find_collider_in_objects(comp_a);
-    auto collider_b_opt = find_collider_in_objects(comp_b);
+    if (auto collider_a_opt =
+            find_collider_in_objects(comp_a, touch_event->shapeIdA);
+        collider_a_opt.has_value()) {
+      if (auto collider_b_opt =
+              find_collider_in_objects(comp_b, touch_event->shapeIdB);
+          collider_b_opt.has_value()) {
+        Collider2D& colA = collider_a_opt->get();
+        Collider2D& colB = collider_b_opt->get();
 
-    if (auto collider_a = collider_a_opt; collider_a.has_value()) {
-      if (auto collider_b = collider_b_opt; collider_b.has_value()) {
-        collider_a->get().on_collision_enter(collider_b->get());
-        collider_b->get().on_collision_enter(collider_a->get());
+        bool aTrigger = colA.creation_flags().sensor;
+        bool bTrigger = colB.creation_flags().sensor;
+
+        if (!aTrigger && !bTrigger) {
+          colA.on_collision_enter(colB);
+          colB.on_collision_enter(colA);
+        } else {
+          colA.on_trigger_enter(colB);
+          colB.on_trigger_enter(colA);
+        }
       }
     }
   }

--- a/src/public/components/colliders/collider_2d.cpp
+++ b/src/public/components/colliders/collider_2d.cpp
@@ -39,9 +39,35 @@ void Collider2D::on_trigger_enter(Collider2D& other) {
   }
 }
 
+size_t Collider2D::add_on_trigger_enter(
+    const std::function<void(Collider2D&, Collider2D&)>& action) {
+  on_trigger_enter_actions_.push_back(action);
+  return on_trigger_enter_actions_.size() - 1;
+}
+
+void Collider2D::remove_on_trigger_enter(int index) {
+  if (index >= 0 &&
+      static_cast<size_t>(index) < on_trigger_enter_actions_.size()) {
+    on_trigger_enter_actions_.erase(on_trigger_enter_actions_.begin() + index);
+  }
+}
+
 void Collider2D::on_trigger_exit(Collider2D& other) {
   for (auto& action : on_trigger_exit_actions_) {
     action(*this, other);
+  }
+}
+
+size_t Collider2D::add_on_trigger_exit(
+    const std::function<void(Collider2D&, Collider2D&)>& action) {
+  on_trigger_exit_actions_.push_back(action);
+  return on_trigger_exit_actions_.size() - 1;
+}
+
+void Collider2D::remove_on_trigger_exit(int index) {
+  if (index >= 0 &&
+      static_cast<size_t>(index) < on_trigger_exit_actions_.size()) {
+    on_trigger_exit_actions_.erase(on_trigger_exit_actions_.begin() + index);
   }
 }
 
@@ -51,9 +77,37 @@ void Collider2D::on_collision_enter(Collider2D& other) {
   }
 }
 
+size_t Collider2D::add_on_collision_enter(
+    const std::function<void(Collider2D&, Collider2D&)>& action) {
+  on_collision_enter_actions_.push_back(action);
+  return on_collision_enter_actions_.size() - 1;
+}
+
+void Collider2D::remove_on_collision_enter(int index) {
+  if (index >= 0 &&
+      static_cast<size_t>(index) < on_collision_enter_actions_.size()) {
+    on_collision_enter_actions_.erase(on_collision_enter_actions_.begin() +
+                                      index);
+  }
+}
+
 void Collider2D::on_collision_exit(Collider2D& other) {
   for (auto& action : on_collision_exit_actions_) {
     action(*this, other);
+  }
+}
+
+size_t Collider2D::add_on_collision_exit(
+    const std::function<void(Collider2D&, Collider2D&)>& action) {
+  on_collision_exit_actions_.push_back(action);
+  return on_collision_exit_actions_.size() - 1;
+}
+
+void Collider2D::remove_on_collision_exit(int index) {
+  if (index >= 0 &&
+      static_cast<size_t>(index) < on_collision_exit_actions_.size()) {
+    on_collision_exit_actions_.erase(on_collision_exit_actions_.begin() +
+                                     index);
   }
 }
 


### PR DESCRIPTION
When looking at player movement I noticed we don't have anything to detect wether we are on the ground. In unity I'd solve it by looking at the object I am colliding with. I tried this and noticed that the collisions do not really work for complex objects that have multiple shapes. So I fixed both. Now you can do something like this:
```cpp
void on_start() override {
    // I also have a box collider on this object.
    auto circle_collider_opt = get_component<CircleCollider2D>();
    if (!circle_collider_opt.has_value()) return;

    auto& circle_collider = circle_collider_opt->get();
    std::cout << "PlayerBehavior started on GameObject "
              << game_object().name() << std::endl;

    // I tagged the gameobject with a tag of "ground"
    circle_collider.add_on_collision_enter(
        [](Collider2D& self, Collider2D& other) {
          auto parent_opt = self.parent();
          if (!parent_opt.has_value()) return;

          auto& parent = parent_opt->get();
          std::cout << "Collided with " << other.parent()->get().name()
                    << " on GameObject " << parent.name() << std::endl;
        });
  }
```
I also altered raycasts so they return the object which has been hit. It just seemed like a nice addition and I can think of a few ways this could be usefull later.