### PR TITLE
feat (ai): add the implementation of the navigation graph generation

### DIFF
--- a/include/engine/core/rendering/renderable.h
+++ b/include/engine/core/rendering/renderable.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <memory>
-
 #include <engine/core/rendering/strategies/irendering_strategy.h>
 #include <engine/public/component.h>
+
+#include <memory>
 
 /**
  * @brief Base class for renderable components in the engine.
@@ -13,11 +13,13 @@
  * defines how the component is rendered. This class extends the Component class
  * and provides functionality to set and retrieve the rendering strategy.
  */
-class Renderable : public Component { // NOLINT
-protected:
+class Renderable : public Component {  // NOLINT
+ protected:
   std::unique_ptr<IRenderingStrategy> render_strategy_;
   int ordering_layer_ = 0;
-public:
+  bool should_draw{true};
+
+ public:
   explicit Renderable();
   explicit Renderable(int layer);
   ~Renderable() override = default;
@@ -27,4 +29,7 @@ public:
 
   void set_render_strategy(Component& component);
   [[nodiscard]] virtual IRenderingStrategy& render_strategy() const;
+
+  Renderable& draw(bool enabled) noexcept;
+  [[nodiscard]] bool draw() const noexcept;
 };

--- a/include/engine/core/rendering/renderable.h
+++ b/include/engine/core/rendering/renderable.h
@@ -17,7 +17,7 @@ class Renderable : public Component {  // NOLINT
  protected:
   std::unique_ptr<IRenderingStrategy> render_strategy_;
   int ordering_layer_ = 0;
-  bool should_draw{true};
+  bool draw{true};
 
  public:
   explicit Renderable();
@@ -30,6 +30,7 @@ class Renderable : public Component {  // NOLINT
   void set_render_strategy(Component& component);
   [[nodiscard]] virtual IRenderingStrategy& render_strategy() const;
 
-  Renderable& draw(bool enabled) noexcept;
-  [[nodiscard]] bool draw() const noexcept;
+  Renderable& disable_draw() noexcept;
+  Renderable& enable_draw() noexcept;
+  [[nodiscard]] bool should_draw() const noexcept;
 };

--- a/include/engine/core/rendering/strategies/sdl/sdl_navigation_node_strategy.h
+++ b/include/engine/core/rendering/strategies/sdl/sdl_navigation_node_strategy.h
@@ -6,12 +6,12 @@
 #include <engine/public/util/color.h>
 
 /**
- * @brief SDL implementation of the box collider 2D rendering strategy.
+ * @brief SDL implementation of the navigation node rendering strategy.
  *
- * SdlBoxCollider2DStrategy is responsible for rendering BoxCollider2D
+ * SdlNavigationNodeStrategy is responsible for rendering NavigationNode
  * components using SDL. It utilizes an SDL_Renderer to draw the associated
- * Texture of the BoxCollider2D component onto the screen, applying
- * transformations and color modulations as specified by the BoxCollider2D.
+ * Texture of the NavigationNode component onto the screen, applying
+ * transformations and color modulations as specified by the NavigationNode.
  */
 class SdlNavigationNodeStrategy final : public IRenderingStrategy {
  private:

--- a/include/engine/core/rendering/strategies/sdl/sdl_navigation_node_strategy.h
+++ b/include/engine/core/rendering/strategies/sdl/sdl_navigation_node_strategy.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <engine/core/rendering/strategies/irendering_strategy.h>
+#include <engine/public/component.h>
+#include <engine/public/util/color.h>
+
+/**
+ * @brief SDL implementation of the box collider 2D rendering strategy.
+ *
+ * SdlBoxCollider2DStrategy is responsible for rendering BoxCollider2D
+ * components using SDL. It utilizes an SDL_Renderer to draw the associated
+ * Texture of the BoxCollider2D component onto the screen, applying
+ * transformations and color modulations as specified by the BoxCollider2D.
+ */
+class SdlNavigationNodeStrategy final : public IRenderingStrategy {
+ private:
+  SDL_Renderer& sdl_renderer_;
+
+ public:
+  SdlNavigationNodeStrategy(SDL_Renderer& sdl_renderer);
+  ~SdlNavigationNodeStrategy() override = default;
+  void draw(Component& component, Camera& camera) override;
+};

--- a/include/engine/public/components/ai/navigation/navigation_graph.h
+++ b/include/engine/public/components/ai/navigation/navigation_graph.h
@@ -15,7 +15,7 @@
  */
 class NavigationGraph : public Component {
  public:
-  NavigationGraph(float node_distance = 1.0f);
+  NavigationGraph(int grid_size = 16, int stride = 10);
 
   /** @brief Update is left empty as the navigation graph does not require
    * per-frame updates */
@@ -70,12 +70,36 @@ class NavigationGraph : public Component {
   std::optional<std::reference_wrapper<NavigationNode>> get_closest_node(
       const GraphPosition& position) const;
 
+  void on_serialize() override{};
+  void on_deserialize() override{};
+
  private:
+  /// Mapping of graph positions to navigation nodes
   std::unordered_map<GraphPosition, std::reference_wrapper<NavigationNode>,
                      GraphPositionHash>
       nodes_;
-  float node_distance_;
 
+  /// Mapping of graph positions to TILES (GameObjects)
+  /// Used to keep track of obstacles when linking nodes
+  std::unordered_map<GraphPosition, GameObject*, GraphPositionHash> tile_map_;
+
+  /// Mapping of graph positions to NODES (NavigationNodes)
+  /// Used to store Nodes on the grid in comparison to tile_map_
+  std::unordered_map<GraphPosition, NavigationNode*, GraphPositionHash>
+      node_tile_map_;
+
+  int stride_ = 10;
+  int max_drop_distance_ = 10;
+  float node_vertical_offset_{16.0f};
+
+  int grid_size_{16};
+  int grid_max_x_{0};
+  int grid_max_y_{0};
+
+  void set_tile_maps(GameObject& parent);
   void generate_nodes();
   void link_nodes();
+
+  std::optional<std::reference_wrapper<NavigationNode>> find_node_in_children(
+      GameObject& parent) const noexcept;
 };

--- a/include/engine/public/components/ai/navigation/navigation_node.h
+++ b/include/engine/public/components/ai/navigation/navigation_node.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <engine/core/rendering/renderable.h>
 #include <engine/public/component.h>
 #include <engine/public/components/ai/navigation/graph.h>
 #include <engine/public/gameObject.h>
@@ -13,7 +14,7 @@
  * This component holds references to neighboring nodes and associated movement
  * costs. It is used in AI pathfinding to navigate through a graph of nodes.
  */
-class NavigationNode : public Component {
+class NavigationNode : public Renderable {
   using Edge = GraphEdge<NavigationNode>;
 
  public:
@@ -48,6 +49,9 @@ class NavigationNode : public Component {
    */
   std::optional<std::reference_wrapper<Edge>> get_edge_to(
       const NavigationNode& neighbor) const;
+
+  void on_serialize() override{};
+  void on_deserialize() override{};
 
  private:
   std::vector<Edge> edges_;

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -75,7 +75,7 @@ class GameObject {
   [[nodiscard]] Transform& transform();
   [[nodiscard]] const Transform& transform() const;
 
-  [[nodiscard]] const Scene& scene() const noexcept;
+  [[nodiscard]] Scene& scene() const noexcept;
   void scene(Scene& scene) noexcept;
 
   [[nodiscard]] std::vector<std::reference_wrapper<GameObject>>& children();

--- a/include/engine/public/transform.h
+++ b/include/engine/public/transform.h
@@ -19,6 +19,7 @@ class Transform {
             std::optional<std::reference_wrapper<Transform>> parent);
 
   [[nodiscard]] Vector3 local_position() const noexcept;
+  Transform& local_position(const Vector3& pos) noexcept;
 
   [[nodiscard]] Vector3 position() const noexcept;
   Transform& position(const Vector3& pos) noexcept;

--- a/src/core/rendering/renderable.cpp
+++ b/src/core/rendering/renderable.cpp
@@ -1,5 +1,7 @@
 #include "engine/core/rendering/renderable.h"
+
 #include <engine/public/util/layers.h>
+
 #include "engine/core/engine.h"
 #include "engine/core/rendering/renderingService.h"
 
@@ -26,3 +28,10 @@ void Renderable::set_render_strategy(Component& component) {
 [[nodiscard]] IRenderingStrategy& Renderable::render_strategy() const {
   return *render_strategy_;
 }
+
+Renderable& Renderable::draw(bool enabled) noexcept {
+  should_draw = enabled;
+  return *this;
+}
+
+bool Renderable::draw() const noexcept { return should_draw; }

--- a/src/core/rendering/renderable.cpp
+++ b/src/core/rendering/renderable.cpp
@@ -29,9 +29,14 @@ void Renderable::set_render_strategy(Component& component) {
   return *render_strategy_;
 }
 
-Renderable& Renderable::draw(bool enabled) noexcept {
-  should_draw = enabled;
+Renderable& Renderable::disable_draw() noexcept {
+  draw = false;
   return *this;
 }
 
-bool Renderable::draw() const noexcept { return should_draw; }
+Renderable& Renderable::enable_draw() noexcept {
+  draw = true;
+  return *this;
+}
+
+bool Renderable::should_draw() const noexcept { return draw; }

--- a/src/core/rendering/strategies/sdl/sdl_navigation_node_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_navigation_node_strategy.cpp
@@ -17,7 +17,7 @@ void SdlNavigationNodeStrategy::draw(Component& component, Camera& camera) {
   if (!dynamic_cast<NavigationNode*>(&component)) return;
 
   NavigationNode& nav_node = dynamic_cast<NavigationNode&>(component);
-  if (!nav_node.draw()) return;
+  if (!nav_node.should_draw()) return;
 
   GameObject& parent = parent_opt->get();
   Vector3 world_pos = parent.transform().position();

--- a/src/core/rendering/strategies/sdl/sdl_navigation_node_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_navigation_node_strategy.cpp
@@ -1,0 +1,54 @@
+#include <engine/core/engine.h>
+#include <engine/core/rendering/assetService.h>
+#include <engine/core/rendering/strategies/sdl/sdl_navigation_node_strategy.h>
+#include <engine/physics/physics_math.h>
+#include <engine/physics/physics_service.h>
+#include <engine/public/components/ai/navigation/navigation_node.h>
+
+constexpr float default_texture_width = 32;
+constexpr float default_texture_height = 32;
+
+SdlNavigationNodeStrategy::SdlNavigationNodeStrategy(SDL_Renderer& sdl_renderer)
+    : sdl_renderer_(sdl_renderer) {}
+
+void SdlNavigationNodeStrategy::draw(Component& component, Camera& camera) {
+  auto parent_opt = component.parent();
+  if (!parent_opt.has_value()) return;
+  if (!dynamic_cast<NavigationNode*>(&component)) return;
+
+  NavigationNode& nav_node = dynamic_cast<NavigationNode&>(component);
+  if (!nav_node.draw()) return;
+
+  GameObject& parent = parent_opt->get();
+  Vector3 world_pos = parent.transform().position();
+  Vector3 cam_pos = camera.transform().position();
+
+  float node_size = 10.0f;
+  SDL_FPoint node_center;
+  node_center.x = world_pos.x - cam_pos.x;
+  node_center.y = world_pos.y - cam_pos.y;
+
+  SDL_FRect rect;
+  rect.w = node_size;
+  rect.h = node_size;
+  rect.x = node_center.x - node_size / 2.0f;
+  rect.y = node_center.y - node_size / 2.0f;
+
+  SDL_SetRenderDrawColor(&sdl_renderer_, 100, 0, 255, 255);
+  SDL_RenderFillRect(&sdl_renderer_, &rect);
+
+  SDL_SetRenderDrawColor(&sdl_renderer_, 255, 0, 0, 255);
+  for (const auto& edge : nav_node.get_edges()) {
+    NavigationNode& target_node = edge.target.get();
+    auto target_parent_opt = target_node.parent();
+    if (!target_parent_opt.has_value()) continue;
+
+    Vector3 target_world_pos = target_parent_opt->get().transform().position();
+
+    SDL_RenderLine(&sdl_renderer_, node_center.x, node_center.y,
+                   target_world_pos.x - cam_pos.x,
+                   target_world_pos.y - cam_pos.y);
+  }
+
+  SDL_SetRenderDrawColor(&sdl_renderer_, 0, 0, 0, 255);
+}

--- a/src/core/rendering/strategies/sdl/sdl_strategy_factory.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_strategy_factory.cpp
@@ -1,9 +1,11 @@
 #include <engine/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.h>
 #include <engine/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.h>
 #include <engine/core/rendering/strategies/sdl/sdl_image_strategy.h>
+#include <engine/core/rendering/strategies/sdl/sdl_navigation_node_strategy.h>
 #include <engine/core/rendering/strategies/sdl/sdl_sprite_strategy.h>
 #include <engine/core/rendering/strategies/sdl/sdl_strategy_factory.h>
 #include <engine/core/rendering/strategies/sdl/sdl_text_strategy.h>
+#include <engine/public/components/ai/navigation/navigation_node.h>
 #include <engine/public/components/colliders/box_collider_2d.h>
 #include <engine/public/components/colliders/circle_collider_2d.h>
 #include <engine/public/components/sprite.h>
@@ -33,6 +35,11 @@ std::unique_ptr<IRenderingStrategy> SdlStrategyFactory::create_strategy(
 
   if (auto* circle_collider = dynamic_cast<CircleCollider2D*>(&component)) {
     return std::make_unique<SdlCircleCollider2DStrategy>(
+        *renderer_.sdl_renderer_);
+  }
+
+  if (auto* navigation_node = dynamic_cast<NavigationNode*>(&component)) {
+    return std::make_unique<SdlNavigationNodeStrategy>(
         *renderer_.sdl_renderer_);
   }
 

--- a/src/public/components/ai/navigation/navigation_graph.cpp
+++ b/src/public/components/ai/navigation/navigation_graph.cpp
@@ -1,19 +1,170 @@
 #include <engine/public/components/ai/navigation/navigation_graph.h>
+#include <engine/public/scene.h>
 
-NavigationGraph::NavigationGraph(float node_distance)
-    : node_distance_(node_distance) {}
+#include <cmath>
+
+NavigationGraph::NavigationGraph(int grid_size, int stride)
+    : grid_size_(grid_size), stride_(stride) {}
 
 NavigationGraph& NavigationGraph::generate_graph() {
-  // implement
+  generate_nodes();
+  link_nodes();
+
   return *this;
 }
 
+std::optional<std::reference_wrapper<NavigationNode>>
+NavigationGraph::find_node_in_children(GameObject& parent) const noexcept {
+  for (auto& child_ref : parent.children()) {
+    GameObject& child = child_ref.get();
+
+    auto node_opt = child.get_component<NavigationNode>();
+    if (node_opt.has_value()) {
+      return node_opt;
+    }
+  }
+
+  return std::nullopt;
+}
+
+void NavigationGraph::set_tile_maps(GameObject& parent) {
+  tile_map_.clear();
+  node_tile_map_.clear();
+  auto& tiles = parent.children();
+
+  // determine grid size (bounds)
+  for (auto& tile_ref : tiles) {
+    GameObject& tile = tile_ref.get();
+    Vector3 pos = tile.transform().position();
+    int gx =
+        static_cast<int>(std::lround(pos.x / static_cast<float>(grid_size_)));
+    int gy =
+        static_cast<int>(std::lround(pos.y / static_cast<float>(grid_size_)));
+    grid_max_x_ = std::max(grid_max_x_, gx) + 1;
+    grid_max_y_ = std::max(grid_max_y_, gy) + 1;
+  }
+
+  // Initialize full grid maps with nullptr
+  for (int y = 0; y <= grid_max_y_; ++y) {
+    for (int x = 0; x <= grid_max_x_; ++x) {
+      GraphPosition gpos{x, y};
+      tile_map_[gpos] = nullptr;
+      node_tile_map_[gpos] = nullptr;
+    }
+  }
+
+  // Fill tile_map_ with actual tiles
+  for (auto& tile_ref : tiles) {
+    GameObject& tile = tile_ref.get();
+    Vector3 pos = tile.transform().position();
+    int gx =
+        static_cast<int>(std::lround(pos.x / static_cast<float>(grid_size_)));
+    int gy =
+        static_cast<int>(std::lround(pos.y / static_cast<float>(grid_size_)));
+    GraphPosition gpos{gx, gy};
+    tile_map_[gpos] = &tile;
+  }
+}
+
 void NavigationGraph::generate_nodes() {
-  // implement
+  clear();
+
+  auto parent_opt = parent();
+  if (!parent_opt.has_value()) return;
+  GameObject& parent_obj = parent_opt->get();
+  auto& tiles = parent_obj.children();
+
+  set_tile_maps(parent_obj);
+
+  // Generate nodes
+  for (int y = 0; y <= grid_max_y_; ++y) {
+    for (int x = 0; x <= grid_max_x_; ++x) {
+      GraphPosition gpos{x, y};
+      if (tile_map_[gpos] == nullptr) continue;
+
+      GameObject* tile = tile_map_[gpos];
+
+      GraphPosition above_pos{gpos.x, gpos.y - 1};
+      GraphPosition left_pos{gpos.x - 1, gpos.y - 1};
+      GraphPosition right_pos{gpos.x + 1, gpos.y - 1};
+
+      bool above = tile_map_.find(above_pos) != tile_map_.end() &&
+                   tile_map_[above_pos] == nullptr;
+      bool left = tile_map_.find(left_pos) != tile_map_.end() &&
+                  tile_map_[left_pos] == nullptr;
+      bool right = tile_map_.find(right_pos) != tile_map_.end() &&
+                   tile_map_[right_pos] == nullptr;
+
+      auto create_node = [this, &parent_obj, &tile](const GraphPosition& pos,
+                                                    float x, float y) {
+        GameObject& node_obj =
+            parent_obj.scene().add_game_object("NavigationNode_");
+        tile->add_child(node_obj);
+
+        Vector3 node_local{};
+        node_local.x = x;
+        node_local.y = y;
+        node_local.z = 0.0f;
+        node_obj.transform().local_position(node_local);
+
+        NavigationNode& nav_node = node_obj.add_component<NavigationNode>();
+        nodes_.emplace(pos, nav_node);
+        node_tile_map_[pos] = &nav_node;
+      };
+
+      if (above)
+        create_node(above_pos, grid_size_ * 0.5f, -node_vertical_offset_);
+      if (above && left)
+        create_node(left_pos, -grid_size_ * 0.5f, -node_vertical_offset_);
+      if (above && right)
+        create_node(right_pos, grid_size_ * 1.5f, -node_vertical_offset_);
+    }
+  }
 }
 
 void NavigationGraph::link_nodes() {
-  // implement
+  if (nodes_.empty()) return;
+
+  // Directions for horizontal scanning
+  const std::array<int, 2> horiz_offsets = {-1, 1};
+
+  for (auto& kv : nodes_) {
+    const GraphPosition& gpos = kv.first;
+    NavigationNode& node = kv.second.get();
+
+    for (int dx : horiz_offsets) {
+      int step = 1;
+      while (true) {
+        GraphPosition check_pos{gpos.x + dx * step, gpos.y};
+
+        if (node_tile_map_.find(check_pos) == node_tile_map_.end()) break;
+        if (tile_map_.find(check_pos) != tile_map_.end() &&
+            tile_map_[check_pos] != nullptr)
+          break;
+
+        if (node_tile_map_[check_pos] != nullptr) {
+          node.add_edge(*node_tile_map_[check_pos], 1.0f);
+          break;
+        }
+
+        ++step;
+      }
+    }
+
+    for (int dy = 1; dy <= max_drop_distance_; ++dy) {
+      GraphPosition check_pos{gpos.x, gpos.y + dy};  // +y => down
+
+      if (node_tile_map_.find(check_pos) == node_tile_map_.end()) break;
+      if (tile_map_.find(check_pos) != tile_map_.end() &&
+          tile_map_[check_pos] != nullptr)
+        break;
+
+      if (node_tile_map_[check_pos] != nullptr) {
+        node.add_edge(*node_tile_map_[check_pos], 1.0f + dy * 0.5f);
+        break;
+      }
+    }
+  }
 }
 
 NavigationGraph& NavigationGraph::clear() {
@@ -45,6 +196,23 @@ NavigationGraph& NavigationGraph::remove_node(const GraphPosition& position) {
 
 std::optional<std::reference_wrapper<NavigationNode>>
 NavigationGraph::get_closest_node(const GraphPosition& position) const {
-  // implement
+  float closest_distance = std::numeric_limits<float>::max();
+  NavigationNode* closest_node = nullptr;
+
+  for (const auto& [pos, node_ref] : nodes_) {
+    float dx = static_cast<float>(pos.x - position.x);
+    float dy = static_cast<float>(pos.y - position.y);
+    float distance = std::sqrt(dx * dx + dy * dy);
+
+    if (distance < closest_distance) {
+      closest_distance = distance;
+      closest_node = &node_ref.get();
+    }
+  }
+
+  if (closest_node) {
+    return std::ref(*closest_node);
+  }
+
   return std::nullopt;
 }

--- a/src/public/components/ai/navigation/navigation_node.cpp
+++ b/src/public/components/ai/navigation/navigation_node.cpp
@@ -6,6 +6,7 @@ NavigationNode::NavigationNode() {
       throw std::runtime_error("Collider2D has no parent GameObject.");
     }
 
+    this->disable_draw();
     this->set_render_strategy(comp);
   });
 }

--- a/src/public/components/ai/navigation/navigation_node.cpp
+++ b/src/public/components/ai/navigation/navigation_node.cpp
@@ -1,6 +1,14 @@
 #include <engine/public/components/ai/navigation/navigation_node.h>
 
-NavigationNode::NavigationNode() = default;
+NavigationNode::NavigationNode() {
+  add_on_attach([this](Component& comp) {
+    if (!parent().has_value()) {
+      throw std::runtime_error("Collider2D has no parent GameObject.");
+    }
+
+    this->set_render_strategy(comp);
+  });
+}
 
 NavigationNode& NavigationNode::add_edge(NavigationNode& neighbor, float cost) {
   GraphEdge<NavigationNode> edge{

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -44,7 +44,7 @@ Transform& GameObject::transform() { return transform_; }
 
 const Transform& GameObject::transform() const { return transform_; }
 
-const Scene& GameObject::scene() const noexcept { return scene_; }
+Scene& GameObject::scene() const noexcept { return scene_; }
 
 void GameObject::scene(Scene& scene) noexcept { scene_ = scene; }
 
@@ -124,11 +124,13 @@ std::vector<std::reference_wrapper<GameObject>>& GameObject::children() {
 GameObject& GameObject::add_child(GameObject& child) {
   children_.emplace_back(child);
   child.parent(*this);
+  child.transform().parent(std::ref(this->transform()));
   return *this;
 }
 
 GameObject& GameObject::remove_child(GameObject& child) {
   std::erase_if(children_, [&](auto& ref) { return &ref.get() == &child; });
+  child.transform().parent(std::nullopt);
   child.parent(std::nullopt);
   return *this;
 }

--- a/src/public/transform.cpp
+++ b/src/public/transform.cpp
@@ -25,6 +25,11 @@ Transform& Transform::position(const Vector3& pos) noexcept {
 
 Vector3 Transform::local_position() const noexcept { return local_position_; }
 
+Transform& Transform::local_position(const Vector3& pos) noexcept {
+  local_position_ = pos;
+  return *this;
+}
+
 Vector3 Transform::position() const noexcept {
   if (!parent_.has_value()) {
     return local_position_;


### PR DESCRIPTION
See #137 for more information. TLDR; the implementation of the navigation graph generation. In order to make this work I also had to tweak some on `GameObject` (scene) and `Transform`. The position thing on `Transform` is going to get its own PR but as I said, I needed it here.

The component generates a graph based on the children of a parent, I also added a debug draw to see the path which can be seen. Down below is an example maze I created, which it accurately produced a graph for.

It does require a little bit of config as to set the grid size and strides it can take. I added the option for weights but don't do anything with it currently.


<img width="795" height="634" alt="image" src="https://github.com/user-attachments/assets/b871f0e7-f0d2-4b46-98fd-de439b66f032" />
