### PR TITLE
feat (transform): fix parent

### DIFF
--- a/include/engine/public/transform.h
+++ b/include/engine/public/transform.h
@@ -19,6 +19,7 @@ class Transform {
             std::optional<std::reference_wrapper<Transform>> parent);
 
   [[nodiscard]] Vector3 local_position() const noexcept;
+  Transform& local_position(const Vector3& pos) noexcept;
 
   [[nodiscard]] Vector3 position() const noexcept;
   Transform& position(const Vector3& pos) noexcept;

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -124,11 +124,13 @@ std::vector<std::reference_wrapper<GameObject>>& GameObject::children() {
 GameObject& GameObject::add_child(GameObject& child) {
   children_.emplace_back(child);
   child.parent(*this);
+  child.transform().parent(std::ref(this->transform()));
   return *this;
 }
 
 GameObject& GameObject::remove_child(GameObject& child) {
   std::erase_if(children_, [&](auto& ref) { return &ref.get() == &child; });
+  child.transform().parent(std::nullopt);
   child.parent(std::nullopt);
   return *this;
 }

--- a/src/public/transform.cpp
+++ b/src/public/transform.cpp
@@ -25,6 +25,11 @@ Transform& Transform::position(const Vector3& pos) noexcept {
 
 Vector3 Transform::local_position() const noexcept { return local_position_; }
 
+Transform& Transform::local_position(const Vector3& pos) noexcept {
+  local_position_ = pos;
+  return *this;
+}
+
 Vector3 Transform::position() const noexcept {
   if (!parent_.has_value()) {
     return local_position_;


### PR DESCRIPTION
> [!NOTE]
> Beware of the usage of position. This changes it so child components have a relative position (which was the idea). So if you have a parent at and set position to 600x600, and the child to a position of 620x620, then now the child will be rendered at 1220x1220.