### PR TITLE
fix (ai): sprite flipping

### DIFF
--- a/include/engine/public/components/sprite.h
+++ b/include/engine/public/components/sprite.h
@@ -28,14 +28,14 @@ class Sprite final : public Renderable {
   std::reference_wrapper<Texture> get_texture_for(const std::string& sprite);
 
  public:
-  Sprite(const std::string& sprite, Color color, int flip_x, int flip_y,
+  Sprite(const std::string& sprite, Color color, bool flip_x, bool flip_y,
          int sorting_layer, int ordering_layer);
 
-  [[nodiscard]] int flip_x() const;
-  Sprite& flip_x(int val);
+  [[nodiscard]] bool flip_x() const;
+  Sprite& flip_x(bool val);
 
-  [[nodiscard]] int flip_y() const;
-  Sprite& flip_y(int val);
+  [[nodiscard]] bool flip_y() const;
+  Sprite& flip_y(bool val);
 
   [[nodiscard]] int sorting_layer() const;
   Sprite& sorting_layer(int val);

--- a/src/core/rendering/strategies/sdl/sdl_sprite_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_sprite_strategy.cpp
@@ -64,10 +64,19 @@ void SdlSpriteStrategy::draw(Component& component, Camera& camera) {
   const Color original_color = get_default_sprite_color(texture_ptr);
   set_sprite_color(sprite.color(), texture_ptr);
 
+  SDL_FlipMode flip_mode = SDL_FLIP_NONE;
+  if (sprite.flip_x() && sprite.flip_y())
+    flip_mode =
+        static_cast<SDL_FlipMode>(SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL);
+  else if (sprite.flip_x())
+    flip_mode = SDL_FLIP_HORIZONTAL;
+  else if (sprite.flip_y())
+    flip_mode = SDL_FLIP_VERTICAL;
+
   SDL_RenderTextureRotated(&sdl_renderer_, texture_ptr, &source, &target,
                            transform.rotation(),
                            nullptr,  // pivot = center
-                           SDL_FLIP_NONE);
+                           flip_mode);
 
   set_sprite_color(original_color, texture_ptr);
 }

--- a/src/public/components/sprite.cpp
+++ b/src/public/components/sprite.cpp
@@ -18,8 +18,8 @@ std::reference_wrapper<Texture> Sprite::get_texture_for(
   return maybe_texture->get();
 }
 
-Sprite::Sprite(const std::string& sprite, const Color color, const int flip_x,
-               const int flip_y, const int sorting_layer,
+Sprite::Sprite(const std::string& sprite, const Color color, const bool flip_x,
+               const bool flip_y, const int sorting_layer,
                const int ordering_layer)
     : texture_(get_texture_for(sprite)),
       flip_x_(flip_x),
@@ -30,14 +30,14 @@ Sprite::Sprite(const std::string& sprite, const Color color, const int flip_x,
   add_on_attach([this](Component& comp) { this->set_render_strategy(comp); });
 }
 
-int Sprite::flip_x() const { return flip_x_; }
-Sprite& Sprite::flip_x(const int val) {
+bool Sprite::flip_x() const { return flip_x_; }
+Sprite& Sprite::flip_x(const bool val) {
   flip_x_ = val;
   return *this;
 }
 
-int Sprite::flip_y() const { return flip_y_; }
-Sprite& Sprite::flip_y(const int val) {
+bool Sprite::flip_y() const { return flip_y_; }
+Sprite& Sprite::flip_y(const bool val) {
   flip_y_ = val;
   return *this;
 }


### PR DESCRIPTION
Sprites had members for flipping, but they were never properly used in the renderer and they were `int` types. Now they are hooked in the strategy and proper `booleans`.

<img width="809" height="628" alt="image" src="https://github.com/user-attachments/assets/d5dc5d62-8369-451b-8b0f-8e2ec350486e" />
