### PR TITLE
fix (camera): add zoom and proper center to rendering

### DIFF
--- a/include/engine/core/rendering/window.h
+++ b/include/engine/core/rendering/window.h
@@ -37,4 +37,10 @@ class Window {
   Window& set_window_resizable();
   Window& set_window_width(unsigned width);
   Window& set_window_height(unsigned height);
+
+  /** @brief Gets the current width of the window. */
+  int get_window_width() const;
+
+  /** @brief Gets the current height of the window. */
+  int get_window_height() const;
 };

--- a/include/engine/public/camera.h
+++ b/include/engine/public/camera.h
@@ -21,4 +21,7 @@ class Camera final : public GameObject {
   void set_main();
   void set_not_main();
   [[nodiscard]] bool is_main() const;
+
+  [[nodiscard]] int get_screen_width() const;
+  [[nodiscard]] int get_screen_height() const;
 };

--- a/src/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.cpp
@@ -28,23 +28,26 @@ void SdlBoxCollider2DStrategy::draw(Component& component, Camera& camera) {
   const auto& position = transform.position();
   const auto& rotation = transform.rotation();
 
-  const auto& camera_position = camera.transform().position();
   const auto& box_collider = dynamic_cast<const BoxCollider2D&>(component);
 
   const auto& body_tf = Body2D::get_pixel_transform(
       parent_opt->get().get_component<Rigidbody2D>().value().get().body());
 
-  float world_x = body_tf.position.x + box_collider.offset().x;
-  float world_y = body_tf.position.y + box_collider.offset().y;
+  const auto& camera_position = camera.transform().position();
+  float zoom = camera.zoom();
 
-  float w = box_collider.width();
-  float h = box_collider.height();
+  float half_screen_width = camera.get_screen_width() * 0.5f;
+  float half_screen_height = camera.get_screen_height() * 0.5f;
 
-  float cx = world_x + w * 0.5f;
-  float cy = world_y + h * 0.5f;
+  const auto& box = dynamic_cast<const BoxCollider2D&>(component);
 
-  float angleDegrees = rotation;
-  float rad = angleDegrees * (PhysicsMath::pi / PhysicsMath::circle_divisor);
+  float cx = body_tf.position.x + box.offset().x + box.width() * 0.5f;
+  float cy = body_tf.position.y + box.offset().y + box.height() * 0.5f;
+
+  float w = box.width();
+  float h = box.height();
+
+  float rad = rotation * (PhysicsMath::pi / PhysicsMath::circle_divisor);
   float cosA = std::cos(rad);
   float sinA = std::sin(rad);
 
@@ -55,29 +58,35 @@ void SdlBoxCollider2DStrategy::draw(Component& component, Camera& camera) {
       {-w * 0.5f, h * 0.5f},
   };
 
-  for (auto& p : corners) {
-    float rx = p.x * cosA - p.y * sinA;
-    float ry = p.x * sinA + p.y * cosA;
+  SDL_FPoint screen_corners[4];
 
-    p.x = rx + cx - camera_position.x;
-    p.y = ry + cy - camera_position.y;
+  for (int i = 0; i < 4; i++) {
+    float rx = corners[i].x * cosA - corners[i].y * sinA;
+    float ry = corners[i].x * sinA + corners[i].y * cosA;
+
+    float wx = cx + rx;
+    float wy = cy + ry;
+
+    screen_corners[i].x = (wx - camera_position.x) * zoom + half_screen_width;
+    screen_corners[i].y = (wy - camera_position.y) * zoom + half_screen_height;
   }
 
   SDL_SetRenderDrawColor(&sdl_renderer_, 0, 255, 0, 255);
 
-  SDL_RenderLine(&sdl_renderer_, corners[0].x, corners[0].y, corners[1].x,
-                 corners[1].y);
-  SDL_RenderLine(&sdl_renderer_, corners[1].x, corners[1].y, corners[2].x,
-                 corners[2].y);
-  SDL_RenderLine(&sdl_renderer_, corners[2].x, corners[2].y, corners[3].x,
-                 corners[3].y);
-  SDL_RenderLine(&sdl_renderer_, corners[3].x, corners[3].y, corners[0].x,
-                 corners[0].y);
+  SDL_RenderLine(&sdl_renderer_, screen_corners[0].x, screen_corners[0].y,
+                 screen_corners[1].x, screen_corners[1].y);
+  SDL_RenderLine(&sdl_renderer_, screen_corners[1].x, screen_corners[1].y,
+                 screen_corners[2].x, screen_corners[2].y);
+  SDL_RenderLine(&sdl_renderer_, screen_corners[2].x, screen_corners[2].y,
+                 screen_corners[3].x, screen_corners[3].y);
+  SDL_RenderLine(&sdl_renderer_, screen_corners[3].x, screen_corners[3].y,
+                 screen_corners[0].x, screen_corners[0].y);
 
-  SDL_RenderLine(&sdl_renderer_, corners[0].x, corners[0].y, corners[2].x,
-                 corners[2].y);
-  SDL_RenderLine(&sdl_renderer_, corners[1].x, corners[1].y, corners[3].x,
-                 corners[3].y);
+  // diagonals for debug
+  SDL_RenderLine(&sdl_renderer_, screen_corners[0].x, screen_corners[0].y,
+                 screen_corners[2].x, screen_corners[2].y);
+  SDL_RenderLine(&sdl_renderer_, screen_corners[1].x, screen_corners[1].y,
+                 screen_corners[3].x, screen_corners[3].y);
 
   SDL_SetRenderDrawColor(&sdl_renderer_, 0, 0, 0, 255);
 }

--- a/src/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.cpp
@@ -82,11 +82,12 @@ void SdlBoxCollider2DStrategy::draw(Component& component, Camera& camera) {
   SDL_RenderLine(&sdl_renderer_, screen_corners[3].x, screen_corners[3].y,
                  screen_corners[0].x, screen_corners[0].y);
 
-  // diagonals for debug
   SDL_RenderLine(&sdl_renderer_, screen_corners[0].x, screen_corners[0].y,
                  screen_corners[2].x, screen_corners[2].y);
   SDL_RenderLine(&sdl_renderer_, screen_corners[1].x, screen_corners[1].y,
                  screen_corners[3].x, screen_corners[3].y);
 
-  SDL_SetRenderDrawColor(&sdl_renderer_, 0, 0, 0, 255);
+  Color original_color = camera.background_color();
+  SDL_SetRenderDrawColor(&sdl_renderer_, original_color.r, original_color.g,
+                         original_color.b, original_color.a);
 }

--- a/src/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.cpp
@@ -84,7 +84,9 @@ void SdlCircleCollider2DStrategy::draw(Component& component, Camera& camera) {
   SDL_RenderLine(&sdl_renderer_, H1.x, H1.y, H2.x, H2.y);
   SDL_RenderLine(&sdl_renderer_, V1.x, V1.y, V2.x, V2.y);
 
-  SDL_SetRenderDrawColor(&sdl_renderer_, 0, 0, 0, 255);
+  Color original_color = camera.background_color();
+  SDL_SetRenderDrawColor(&sdl_renderer_, original_color.r, original_color.g,
+                         original_color.b, original_color.a);
 }
 
 void SdlCircleCollider2DStrategy::draw_circle(int cx, int cy, int radius) {

--- a/src/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.cpp
@@ -27,6 +27,11 @@ void SdlCircleCollider2DStrategy::draw(Component& component, Camera& camera) {
 
   const auto& transform = parent_opt->get().transform();
   const auto& camera_position = camera.transform().position();
+  float zoom = camera.zoom();
+
+  float half_screen_width = camera.get_screen_width() * 0.5f;
+  float half_screen_height = camera.get_screen_height() * 0.5f;
+
   const auto& circle_collider =
       dynamic_cast<const CircleCollider2D&>(component);
 
@@ -46,12 +51,17 @@ void SdlCircleCollider2DStrategy::draw(Component& component, Camera& camera) {
   float rx = ox * cosA - oy * sinA;
   float ry = ox * sinA + oy * cosA;
 
-  Point center{body_tf.position.x + rx - camera_position.x,
-               body_tf.position.y + ry - camera_position.y};
+  float world_cx = body_tf.position.x + rx;
+  float world_cy = body_tf.position.y + ry;
+
+  Point center{(world_cx - camera_position.x) * zoom + half_screen_width,
+               (world_cy - camera_position.y) * zoom + half_screen_height};
+
+  float screen_radius = radius_px * zoom;
 
   SDL_SetRenderDrawColor(&sdl_renderer_, 255, 0, 0, 255);
 
-  draw_circle((int)center.x, (int)center.y, (int)radius_px);
+  draw_circle((int)center.x, (int)center.y, (int)screen_radius);
 
   auto rotate_local = [&](float lx, float ly) -> SDL_FPoint {
     return {lx * cosA - ly * sinA, lx * sinA + ly * cosA};

--- a/src/core/rendering/strategies/sdl/sdl_sprite_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_sprite_strategy.cpp
@@ -40,7 +40,12 @@ void SdlSpriteStrategy::draw(Component& component, Camera& camera) {
 
   const auto& transform = parent_opt->get().transform();
   const auto& position = transform.position();
+
   const auto& camera_position = camera.transform().position();
+  const auto zoom = camera.zoom();
+
+  const auto half_screen_width = camera.get_screen_width() * 0.5f;
+  const auto half_screen_height = camera.get_screen_height() * 0.5f;
 
   const auto& sprite = dynamic_cast<const Sprite&>(component);
   const Texture& texture = sprite.texture();
@@ -56,10 +61,15 @@ void SdlSpriteStrategy::draw(Component& component, Camera& camera) {
 
   auto const source = SDL_FRect{.x = 0, .y = 0, .w = width, .h = height};
 
-  auto const target = SDL_FRect{.x = position.x - camera_position.x,
-                                .y = position.y - camera_position.y,
-                                .w = width * transform.scale().x,
-                                .h = height * transform.scale().y};
+  /// We need to convert world coordinates to screen coordinates, taking
+  /// into account the camera position, zoom level and screen center offset.
+  /// Note that I made the camera's position at the center of the screen to copy
+  /// Unity in that aspect.
+  auto const target = SDL_FRect{
+      .x = (position.x - camera_position.x) * zoom + half_screen_width,
+      .y = (position.y - camera_position.y) * zoom + half_screen_height,
+      .w = width * transform.scale().x * zoom,
+      .h = height * transform.scale().y * zoom};
 
   const Color original_color = get_default_sprite_color(texture_ptr);
   set_sprite_color(sprite.color(), texture_ptr);

--- a/src/core/rendering/window.cpp
+++ b/src/core/rendering/window.cpp
@@ -46,3 +46,15 @@ Window& Window::set_window_height(unsigned height) {
   SDL_SetWindowSize(window_, current_width, static_cast<int>(height));
   return *this;
 }
+
+int Window::get_window_width() const {
+  int width{};
+  SDL_GetWindowSize(window_, &width, nullptr);
+  return width;
+}
+
+int Window::get_window_height() const {
+  int height{};
+  SDL_GetWindowSize(window_, nullptr, &height);
+  return height;
+}

--- a/src/public/camera.cpp
+++ b/src/public/camera.cpp
@@ -1,3 +1,6 @@
+#include <engine/core/engine.h>
+#include <engine/core/rendering/renderingService.h>
+#include <engine/core/rendering/window.h>
 #include <engine/public/camera.h>
 #include <engine/public/scene.h>
 
@@ -37,3 +40,21 @@ void Camera::set_main() {
 void Camera::set_not_main() { isMain_ = false; }
 
 bool Camera::is_main() const { return isMain_; }
+
+int Camera::get_screen_width() const {
+  auto& window = Engine::instance()
+                     .services->get_service<RenderingService>()
+                     .get()
+                     .window();
+
+  return window.get_window_width();
+}
+
+int Camera::get_screen_height() const {
+  auto& window = Engine::instance()
+                     .services->get_service<RenderingService>()
+                     .get()
+                     .window();
+
+  return window.get_window_height();
+}


### PR DESCRIPTION
I noticed that the camera has a zoom property but doesn't do anything with it. I figured we might increase the zoom in our game, so that is why this PR has come to be.

It adds the option to retrieve the width/height from window and camera. That way we can utilize this in our calculations for positions in render strategies. `Image` and `Text` are left alone as they are UI strategies which still work fine. They are positioned without camera positions/zoom.

I tested this with my own little behavior and it seems to work/draw fine. You can make it follow something like so:
```cpp
auto camera = game_object().scene().main_camera();
    if (camera.has_value()) {
      auto& cam = camera->get();

      cam.transform().position({
          game_object().transform().position().x,
          game_object().transform().position().y,
          0.0f
      });
    } 
 ```

https://github.com/user-attachments/assets/7467d30f-d225-4359-9acc-15e4a32bb898


