### PR TITLE
fix (physics): fix sensor events + debug draws for types + offset

### DIFF
--- a/include/engine/physics/creation/physics_creation_flags.h
+++ b/include/engine/physics/creation/physics_creation_flags.h
@@ -43,6 +43,19 @@ struct PhysicsCreationFlags {
   bool enable_contact_events{true};
 
   /**
+   * @brief Whether to enable sensor events for the body
+   *
+   * Default is true.
+   * If true, the body will generate events when other bodies enter/exit the
+   * sensor.
+   *
+   * @note: This is an optimization flag but a TRICKY one.
+   * Sensors need this, aswell as their collidable objects.
+   * Supports: kinematic, dynamic and static.
+   */
+  bool enable_sensor_events{true};
+
+  /**
    * @brief Whether the body is treated as a bullet
    *
    * Default is false.

--- a/include/engine/public/components/colliders/box_collider_2d.h
+++ b/include/engine/public/components/colliders/box_collider_2d.h
@@ -19,7 +19,8 @@ class BoxCollider2D : public Collider2D {
   BoxCollider2D(float friction, float bounciness,
                 float width = default_box_collider_width,
                 float height = default_box_collider_height,
-                Point offset = {0.0f, 0.0f});
+                Point offset = {0.0f, 0.0f}, bool is_sensor = false,
+                bool is_bullet = false);
   ~BoxCollider2D() override = default;
 
   void update(float dt) override;
@@ -35,6 +36,9 @@ class BoxCollider2D : public Collider2D {
 
   BoxCollider2D& friction(float value) noexcept override;
   BoxCollider2D& bounciness(float value) noexcept override;
+
+  [[nodiscard]] Point offset() const noexcept override;
+  BoxCollider2D& offset(Point value) noexcept override;
 
  private:
   float width_;

--- a/include/engine/public/components/colliders/circle_collider_2d.h
+++ b/include/engine/public/components/colliders/circle_collider_2d.h
@@ -31,6 +31,9 @@ class CircleCollider2D : public Collider2D {
   CircleCollider2D& friction(float value) noexcept override;
   CircleCollider2D& bounciness(float value) noexcept override;
 
+  [[nodiscard]] Point offset() const noexcept override;
+  CircleCollider2D& offset(Point value) noexcept override;
+
  private:
   float radius_;
 };

--- a/include/engine/public/components/colliders/collider_2d.h
+++ b/include/engine/public/components/colliders/collider_2d.h
@@ -107,15 +107,16 @@ class Collider2D : public Renderable {
   PhysicsCreationFlags& creation_flags() noexcept;
   Collider2D& creation_flags(PhysicsCreationFlags value) noexcept;
 
-  [[nodiscard]] Point offset() const noexcept;
-  Collider2D& offset(Point value) noexcept;
+  [[nodiscard]] virtual Point offset() const noexcept;
+  virtual Collider2D& offset(Point value) noexcept;
 
- private:
+ protected:
   PhysicsCreationFlags creation_flags_{};
   float friction_;
   float bounciness_;
   Point offset_;
 
+ private:
   std::vector<std::function<void(Collider2D&, Collider2D&)>>
       on_trigger_enter_actions_;
   std::vector<std::function<void(Collider2D&, Collider2D&)>>

--- a/src/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.cpp
@@ -1,6 +1,7 @@
 #include <engine/core/engine.h>
 #include <engine/core/rendering/assetService.h>
 #include <engine/core/rendering/strategies/sdl/sdl_box_collider_2d_strategy.h>
+#include <engine/physics/creation/physics_creation_flags.h>
 #include <engine/physics/physics_math.h>
 #include <engine/physics/physics_service.h>
 #include <engine/public/components/colliders/box_collider_2d.h>
@@ -28,7 +29,7 @@ void SdlBoxCollider2DStrategy::draw(Component& component, Camera& camera) {
   const auto& position = transform.position();
   const auto& rotation = transform.rotation();
 
-  const auto& box_collider = dynamic_cast<const BoxCollider2D&>(component);
+  auto& box_collider = dynamic_cast<BoxCollider2D&>(component);
 
   const auto& body_tf = Body2D::get_pixel_transform(
       parent_opt->get().get_component<Rigidbody2D>().value().get().body());
@@ -71,7 +72,19 @@ void SdlBoxCollider2DStrategy::draw(Component& component, Camera& camera) {
     screen_corners[i].y = (wy - camera_position.y) * zoom + half_screen_height;
   }
 
-  SDL_SetRenderDrawColor(&sdl_renderer_, 0, 255, 0, 255);
+  BodyType2D::Type body_type = box_collider.get_rigidbody().get().type();
+
+  switch (body_type) {
+    case BodyType2D::Static:
+      SDL_SetRenderDrawColor(&sdl_renderer_, 255, 0, 0, 255);
+      break;
+    case BodyType2D::Kinematic:
+      SDL_SetRenderDrawColor(&sdl_renderer_, 0, 0, 255, 255);
+      break;
+    case BodyType2D::Dynamic:
+      SDL_SetRenderDrawColor(&sdl_renderer_, 0, 255, 0, 255);
+      break;
+  }
 
   SDL_RenderLine(&sdl_renderer_, screen_corners[0].x, screen_corners[0].y,
                  screen_corners[1].x, screen_corners[1].y);

--- a/src/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.cpp
+++ b/src/core/rendering/strategies/sdl/sdl_circle_collider_2d_strategy.cpp
@@ -32,8 +32,7 @@ void SdlCircleCollider2DStrategy::draw(Component& component, Camera& camera) {
   float half_screen_width = camera.get_screen_width() * 0.5f;
   float half_screen_height = camera.get_screen_height() * 0.5f;
 
-  const auto& circle_collider =
-      dynamic_cast<const CircleCollider2D&>(component);
+  auto& circle_collider = dynamic_cast<CircleCollider2D&>(component);
 
   const auto& body_tf = Body2D::get_pixel_transform(
       parent_opt->get().get_component<Rigidbody2D>().value().get().body());
@@ -59,7 +58,19 @@ void SdlCircleCollider2DStrategy::draw(Component& component, Camera& camera) {
 
   float screen_radius = radius_px * zoom;
 
-  SDL_SetRenderDrawColor(&sdl_renderer_, 255, 0, 0, 255);
+  BodyType2D::Type body_type = circle_collider.get_rigidbody().get().type();
+
+  switch (body_type) {
+    case BodyType2D::Static:
+      SDL_SetRenderDrawColor(&sdl_renderer_, 255, 0, 0, 255);
+      break;
+    case BodyType2D::Kinematic:
+      SDL_SetRenderDrawColor(&sdl_renderer_, 0, 0, 255, 255);
+      break;
+    case BodyType2D::Dynamic:
+      SDL_SetRenderDrawColor(&sdl_renderer_, 0, 255, 0, 255);
+      break;
+  }
 
   draw_circle((int)center.x, (int)center.y, (int)screen_radius);
 

--- a/src/physics/creation/physics_creation_factory.cpp
+++ b/src/physics/creation/physics_creation_factory.cpp
@@ -75,6 +75,7 @@ Body2D PhysicsCreationFactory::create_box_fixture(Body2D body, Point offset,
 
   b2ShapeDef shape_def = b2DefaultShapeDef();
   shape_def.enableContactEvents = flags.enable_contact_events;
+  shape_def.enableSensorEvents = flags.enable_sensor_events;
   shape_def.isSensor = flags.sensor;
 
   float density = 0.0f;
@@ -106,6 +107,10 @@ Body2D PhysicsCreationFactory::create_box_fixture(Body2D body, Point offset,
     b2Shape_EnableContactEvents(shape_id, true);
   }
 
+  if (flags.enable_sensor_events) {
+    b2Shape_EnableSensorEvents(shape_id, true);
+  }
+
   if (flags.is_bullet) {
     b2MassData mass_data;
     mass_data.mass = base_mass;
@@ -133,6 +138,7 @@ Body2D PhysicsCreationFactory::create_circle_fixture(
   b2ShapeDef shape_def = b2DefaultShapeDef();
 
   shape_def.enableContactEvents = flags.enable_contact_events;
+  shape_def.enableSensorEvents = flags.enable_sensor_events;
   shape_def.isSensor = flags.sensor;
   float density = 0.0f;
 
@@ -164,6 +170,10 @@ Body2D PhysicsCreationFactory::create_circle_fixture(
 
   if (flags.enable_contact_events) {
     b2Shape_EnableContactEvents(shape_id, true);
+  }
+
+  if (flags.enable_sensor_events) {
+    b2Shape_EnableSensorEvents(shape_id, true);
   }
 
   if (flags.is_bullet) {

--- a/src/physics/world/physics_world.cpp
+++ b/src/physics/world/physics_world.cpp
@@ -86,8 +86,8 @@ void PhysicsWorld::check_collision(
         Collider2D& colA = collider_a_opt->get();
         Collider2D& colB = collider_b_opt->get();
 
-        colA.on_collision_enter(colB);
-        colB.on_collision_enter(colA);
+        if (colA.active()) colA.on_collision_enter(colB);
+        if (colB.active()) colB.on_collision_enter(colA);
       }
     }
   }
@@ -117,8 +117,10 @@ void PhysicsWorld::check_collision(
         Collider2D& colA = collider_a_opt->get();
         Collider2D& colB = collider_b_opt->get();
 
-        if (colA.creation_flags().sensor) colA.on_trigger_enter(colB);
-        if (colB.creation_flags().sensor) colB.on_trigger_enter(colA);
+        if (colA.creation_flags().sensor && colA.active())
+          colA.on_trigger_enter(colB);
+        if (colB.creation_flags().sensor && colB.active())
+          colB.on_trigger_enter(colA);
       }
     }
   }

--- a/src/physics/world/physics_world.cpp
+++ b/src/physics/world/physics_world.cpp
@@ -27,63 +27,55 @@ void PhysicsWorld::step(float dt) {
 
 void PhysicsWorld::check_collision(
     const std::vector<std::reference_wrapper<GameObject>>& objects) {
+  auto find_collider_in_objects = [&](Component* comp, b2ShapeId shape_id)
+      -> std::optional<std::reference_wrapper<Collider2D>> {
+    for (const auto& obj_ref : objects) {
+      GameObject& obj = obj_ref.get();
+      auto collider_opts = obj.get_components<Collider2D>();
+
+      for (auto& collider_opt : collider_opts) {
+        Collider2D& collider = collider_opt.get();
+        auto shapes = collider.get_rigidbody().get().body().shapes;
+
+        for (const auto& shape : shapes) {
+          if (shape.id.index1 == shape_id.index1 &&
+              shape.id.generation == shape_id.generation) {
+            // Match shape type
+            b2ShapeType collider_shape_type;
+            if (dynamic_cast<BoxCollider2D*>(&collider)) {
+              collider_shape_type = b2ShapeType::b2_polygonShape;
+            } else if (dynamic_cast<CircleCollider2D*>(&collider)) {
+              collider_shape_type = b2ShapeType::b2_circleShape;
+            } else {
+              continue;
+            }
+
+            if (collider.parent()->get().id() == comp->parent()->get().id() &&
+                collider_shape_type == shape.type) {
+              return std::ref(collider);
+            }
+          }
+        }
+      }
+    }
+    return std::nullopt;
+  };
+
+  /// Check contact (collision) events
   b2ContactEvents contact_events = b2World_GetContactEvents(world_id_);
   for (int i = 0; i < contact_events.beginCount; ++i) {
     b2ContactBeginTouchEvent* touch_event = contact_events.beginEvents + i;
 
     if (!b2Shape_IsValid(touch_event->shapeIdA) ||
-        !b2Shape_IsValid(touch_event->shapeIdB)) {
+        !b2Shape_IsValid(touch_event->shapeIdB))
       continue;
-    }
 
-    // Get the bodies associated with the shapes
     b2BodyId body_a = b2Shape_GetBody(touch_event->shapeIdA);
     b2BodyId body_b = b2Shape_GetBody(touch_event->shapeIdB);
     auto* comp_a = static_cast<Component*>(b2Body_GetUserData(body_a));
     auto* comp_b = static_cast<Component*>(b2Body_GetUserData(body_b));
 
-    auto find_collider_in_objects = [&](Component* comp, b2ShapeId shape_id)
-        -> std::optional<std::reference_wrapper<Collider2D>> {
-      for (const auto& obj_ref : objects) {
-        GameObject& obj = obj_ref.get();
-        auto collider_opt = obj.get_component<Collider2D>();
-        auto collider_opts = obj.get_components<Collider2D>();
-
-        for (auto& collider_opt : collider_opts) {
-          Collider2D& collider = collider_opt.get();
-
-          auto shapes = collider.get_rigidbody().get().body().shapes;
-          bool shape_found = false;
-          b2ShapeType shape_type;
-
-          for (const auto& shape : shapes) {
-            if (shape.id.index1 == shape_id.index1 &&
-                shape.id.generation == shape_id.generation) {
-              shape_found = true;
-              shape_type = shape.type;
-              break;
-            }
-          }
-
-          // Check for the collider type currently in the loop
-          b2ShapeType collider_shape_type;
-          if (auto box = dynamic_cast<BoxCollider2D*>(&collider)) {
-            collider_shape_type = b2ShapeType::b2_polygonShape;
-          } else if (auto circle = dynamic_cast<CircleCollider2D*>(&collider)) {
-            collider_shape_type = b2ShapeType::b2_circleShape;
-          } else {
-            return std::nullopt;
-          }
-
-          if (collider.parent()->get().id() == comp->parent()->get().id() &&
-              collider_shape_type == shape_type && shape_found) {
-            return std::ref(collider);
-          }
-        }
-      }
-
-      return std::nullopt;
-    };
+    if (!comp_a || !comp_b) continue;
 
     if (auto collider_a_opt =
             find_collider_in_objects(comp_a, touch_event->shapeIdA);
@@ -94,16 +86,39 @@ void PhysicsWorld::check_collision(
         Collider2D& colA = collider_a_opt->get();
         Collider2D& colB = collider_b_opt->get();
 
-        bool aTrigger = colA.creation_flags().sensor;
-        bool bTrigger = colB.creation_flags().sensor;
+        colA.on_collision_enter(colB);
+        colB.on_collision_enter(colA);
+      }
+    }
+  }
 
-        if (!aTrigger && !bTrigger) {
-          colA.on_collision_enter(colB);
-          colB.on_collision_enter(colA);
-        } else {
-          colA.on_trigger_enter(colB);
-          colB.on_trigger_enter(colA);
-        }
+  /// Check sensor (trigger) events
+  b2SensorEvents sensor_events = b2World_GetSensorEvents(world_id_);
+  for (int i = 0; i < sensor_events.beginCount; ++i) {
+    b2SensorBeginTouchEvent* touch_event = sensor_events.beginEvents + i;
+
+    if (!b2Shape_IsValid(touch_event->sensorShapeId) ||
+        !b2Shape_IsValid(touch_event->visitorShapeId))
+      continue;
+
+    b2BodyId body_a = b2Shape_GetBody(touch_event->sensorShapeId);
+    b2BodyId body_b = b2Shape_GetBody(touch_event->visitorShapeId);
+    auto* comp_a = static_cast<Component*>(b2Body_GetUserData(body_a));
+    auto* comp_b = static_cast<Component*>(b2Body_GetUserData(body_b));
+
+    if (!comp_a || !comp_b) continue;
+
+    if (auto collider_a_opt =
+            find_collider_in_objects(comp_a, touch_event->sensorShapeId);
+        collider_a_opt.has_value()) {
+      if (auto collider_b_opt =
+              find_collider_in_objects(comp_b, touch_event->visitorShapeId);
+          collider_b_opt.has_value()) {
+        Collider2D& colA = collider_a_opt->get();
+        Collider2D& colB = collider_b_opt->get();
+
+        if (colA.creation_flags().sensor) colA.on_trigger_enter(colB);
+        if (colB.creation_flags().sensor) colB.on_trigger_enter(colA);
       }
     }
   }

--- a/src/public/components/colliders/box_collider_2d.cpp
+++ b/src/public/components/colliders/box_collider_2d.cpp
@@ -4,9 +4,11 @@
 #include <stdexcept>
 
 BoxCollider2D::BoxCollider2D(float friction, float bounciness, float width,
-                             float height, Point offset)
+                             float height, Point offset, bool is_sensor,
+                             bool is_bullet)
     : Collider2D(friction, bounciness, offset), width_(width), height_(height) {
-  auto on_awake = [this, offset, friction, bounciness](Component& comp) {
+  auto on_awake = [this, offset, friction, bounciness, is_sensor,
+                   is_bullet](Component& comp) {
     if (!parent().has_value()) {
       throw std::runtime_error("BoxCollider2D has no parent GameObject.");
     }
@@ -35,6 +37,8 @@ BoxCollider2D::BoxCollider2D(float friction, float bounciness, float width,
       flags.desired_mass = rigidbody.mass();
       flags.bounciness = bounciness;
       flags.friction = friction;
+      flags.sensor = is_sensor;
+      flags.is_bullet = is_bullet;
 
       auto transform = gameobject.transform();
       rigidbody.body(PhysicsCreationFactory::create_box_fixture(
@@ -57,7 +61,8 @@ BoxCollider2D& BoxCollider2D::width(float value) noexcept {
   width_ = value;
 
   auto& rigidbody = get_rigidbody().get();
-  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f}, offset());
+  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f},
+                        Collider2D::offset());
 
   return *this;
 }
@@ -68,7 +73,8 @@ BoxCollider2D& BoxCollider2D::height(float value) noexcept {
   height_ = value;
 
   auto& rigidbody = get_rigidbody().get();
-  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f}, offset());
+  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f},
+                        Collider2D::offset());
 
   return *this;
 }
@@ -87,6 +93,17 @@ BoxCollider2D& BoxCollider2D::bounciness(float value) noexcept {
 
   auto& rigidbody = get_rigidbody().get();
   Body2D::set_body_bounciness(rigidbody.body(), value, ShapeType2D::Polygon);
+
+  return *this;
+}
+
+Point BoxCollider2D::offset() const noexcept { return Collider2D::offset(); }
+
+BoxCollider2D& BoxCollider2D::offset(Point value) noexcept {
+  Collider2D::offset(value);
+
+  auto& rigidbody = get_rigidbody().get();
+  Body2D::set_body_size(rigidbody.body(), {width_, height_, 0.0f}, value);
 
   return *this;
 }

--- a/src/public/components/colliders/circle_collider_2d.cpp
+++ b/src/public/components/colliders/circle_collider_2d.cpp
@@ -78,3 +78,14 @@ CircleCollider2D& CircleCollider2D::bounciness(float value) noexcept {
 
   return *this;
 }
+
+Point CircleCollider2D::offset() const noexcept { return Collider2D::offset(); }
+
+CircleCollider2D& CircleCollider2D::offset(Point value) noexcept {
+  Collider2D::offset(value);
+
+  auto& rigidbody = get_rigidbody().get();
+  Body2D::set_body_radius(rigidbody.body(), radius_, offset());
+
+  return *this;
+}

--- a/src/public/components/rigidbody_2d.cpp
+++ b/src/public/components/rigidbody_2d.cpp
@@ -43,17 +43,30 @@ Rigidbody2D::Rigidbody2D(BodyType2D::Type type, float mass, bool use_gravity,
 Rigidbody2D::~Rigidbody2D() = default;
 
 void Rigidbody2D::update(float dt) {
-  auto& physics_service =
-      Engine::instance().services->get_service<PhysicsService>().get();
+  auto& gameobject = parent()->get();
+  auto& tf = gameobject.transform();
 
-  if (auto parent_opt = parent(); parent_opt.has_value()) {
-    auto& gameobject = parent_opt->get();
-    Body2DTransform transform = Body2D::get_pixel_transform(body_);
-    transform.position = PhysicsMath::physics_vec3_to_transform_pixel_vec3(
-        transform.position, 0, 0);
-    gameobject.transform().position(transform.position);
-    gameobject.transform().rotation(transform.rotation);
+  /// Dynamic bodies: Update GameObject transform from physics body
+  if (type_ == BodyType2D::Dynamic) {
+    Body2DTransform body_tf = Body2D::get_pixel_transform(body_);
+    body_tf.position = PhysicsMath::physics_vec3_to_transform_pixel_vec3(
+        body_tf.position, 0, 0);
+
+    tf.position(body_tf.position);
+    tf.rotation(body_tf.rotation);
   }
+  /// Kinematic bodies: Update physics body from GameObject transform
+  else if (type_ == BodyType2D::Kinematic) {
+    Vector3 world_pos = tf.position();
+    float world_rot = tf.rotation();
+
+    Body2DTransform body_tf = Body2D::get_pixel_transform(body_);
+    body_tf.position = world_pos;
+    body_tf.rotation = world_rot;
+
+    Body2D::set_body_transform(body_tf, true);
+  }
+  /// Static bodies: Do nothing
 }
 
 void Rigidbody2D::on_serialize() {


### PR DESCRIPTION
This is to fix the bug of sensor fixtures not being detected. It took a very long time to find and fix this... Its my bad for overlooking but oh man does it sting.

In case you don't know what `fixtures` are, they are the collidable boundaries which an object has. A sensor fixture is an object that collides, but never applies force. Its pretty much a ghost object. The reason we need this is for example hitboxes. If I swing an axe its easier to cast a box of where that axe would hit and check it rather than complex casts or whatnot.