### PR TITLE
update (cmake): make enet public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,8 @@ add_library(engine ${ENGINE_SOURCES} ${IMGUI_SOURCES})
 target_include_directories(engine
     PUBLIC 
         ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PRIVATE 
         ${enet_SOURCE_DIR}/include
+    PRIVATE 
         ${imgui_SOURCE_DIR} 
         ${imgui_SOURCE_DIR}/backends
 )


### PR DESCRIPTION
Enet has to be publicly accessible for it to be usable in the game. We don't use it directly but we do call classes that require this.