### PR TITLE
fix (scene): game object deletion

### DIFF
--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -30,7 +30,8 @@ class GameObject {
 
   bool marked_for_deletion_{false};
   bool dont_destroy_on_load_{false};
-  std::string prefab_type_id_{};  // Identifier for prefab type used during network replication
+  std::string prefab_type_id_{};  // Identifier for prefab type used during
+                                  // network replication
 
  public:
   explicit GameObject(Scene& scene);
@@ -60,7 +61,7 @@ class GameObject {
   [[nodiscard]] bool marked_for_deletion() const noexcept;
 
   /* Only applicable for parent objects. Child objects are unaffected */
-  void mark_dont_destroy_on_load(bool destroy) noexcept;
+  void mark_dont_destroy_on_load(bool dont_destroy) noexcept;
   bool dont_destroy_on_load() const noexcept;
 
   GameObject& name(const std::string& name);
@@ -155,6 +156,8 @@ class GameObject {
                        }),
         components_.end());
   }
+
+  void remove_all_components();
 
   /**
    * Serialize this GameObject's own state and its components into `out`.

--- a/include/engine/public/scene.h
+++ b/include/engine/public/scene.h
@@ -69,6 +69,7 @@ class Scene {
 
   std::unique_ptr<GameObject> extract_game_object(GameObject& game_object);
   bool remove_game_object(GameObject& game_object);
+  void cleanup_destroyed_game_objects();
 
   [[nodiscard]] std::optional<std::reference_wrapper<Camera>> main_camera()
       const;

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -1,13 +1,13 @@
+#include <engine/network/snapshot.h>
 #include <engine/public/component.h>
 #include <engine/public/gameObject.h>
 #include <engine/public/scene.h>
 #include <engine/util/uuid.h>
-#include <engine/network/snapshot.h>
 
+#include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <vector>
-#include <cstring>
-#include <cstdint>
 
 GameObject::GameObject(Scene& scene)
     : id_(uuid::generate_uuid_v4()), scene_(scene) {}
@@ -40,7 +40,9 @@ GameObject& GameObject::prefab_type_id(const std::string& id) {
   prefab_type_id_ = id;
   return *this;
 }
-const std::string& GameObject::prefab_type_id() const { return prefab_type_id_; }
+const std::string& GameObject::prefab_type_id() const {
+  return prefab_type_id_;
+}
 
 GameObject& GameObject::layer(const int layer) {
   layer_ = layer;
@@ -92,9 +94,9 @@ GameObject& GameObject::mark_for_deletion() noexcept {
   return *this;
 }
 
-void GameObject::mark_dont_destroy_on_load(const bool destroy) noexcept {
+void GameObject::mark_dont_destroy_on_load(const bool dont_destroy) noexcept {
   if (!parent().has_value()) {
-    dont_destroy_on_load_ = destroy;
+    dont_destroy_on_load_ = dont_destroy;
   }
 }
 
@@ -133,13 +135,22 @@ std::vector<std::reference_wrapper<GameObject>>& GameObject::children() {
   return children_;
 }
 
-std::vector<std::reference_wrapper<Component>> GameObject::get_components_all() const {
+std::vector<std::reference_wrapper<Component>> GameObject::get_components_all()
+    const {
   std::vector<std::reference_wrapper<Component>> result;
   result.reserve(components_.size());
   for (const auto& c : components_) {
     result.emplace_back(*c);
   }
   return result;
+}
+
+void GameObject::remove_all_components() {
+  for (auto& component : components_) {
+    component->on_detach();
+    component->parent(std::nullopt);
+  }
+  components_.clear();
 }
 
 GameObject& GameObject::add_child(GameObject& child) {
@@ -186,7 +197,8 @@ void GameObject::serialize(std::vector<uint8_t>& out) const {
   for (auto& c : comps) {
     std::vector<uint8_t> cp;
     c.get().on_serialize(cp);
-    if (!cp.empty()) comp_entries.emplace_back(c.get().type_name(), std::move(cp));
+    if (!cp.empty())
+      comp_entries.emplace_back(c.get().type_name(), std::move(cp));
   }
 
   uint16_t comp_count = static_cast<uint16_t>(comp_entries.size());
@@ -236,14 +248,17 @@ void GameObject::deserialize(const std::vector<uint8_t>& data, size_t& offset) {
 
   // Deserialize components
   uint16_t comp_count = 0;
-  if (!snapshot::read_bytes(data, offset, &comp_count, sizeof(comp_count))) return;
+  if (!snapshot::read_bytes(data, offset, &comp_count, sizeof(comp_count)))
+    return;
 
   for (uint16_t i = 0; i < comp_count; ++i) {
     std::string type_name;
     if (!snapshot::read_string(data, offset, type_name)) break;
 
     uint32_t payload_length = 0;
-    if (!snapshot::read_bytes(data, offset, &payload_length, sizeof(payload_length))) break;
+    if (!snapshot::read_bytes(data, offset, &payload_length,
+                              sizeof(payload_length)))
+      break;
 
     // Dispatch payload to matching component
     bool applied = false;

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -148,9 +148,7 @@ void Scene::game_loop() {  // NOLINT [readability-make-member-function-const]
       rendering_service.draw(layered_renderables, *this);
 
       // 5. cleanup marked for deletion game objects AFTER rendering
-      for (auto& game_object_ref : marked_for_deletion) {
-        remove_game_object(game_object_ref.get());
-      }
+      cleanup_destroyed_game_objects();
     });
   }
 }
@@ -280,9 +278,22 @@ bool Scene::remove_game_object(GameObject& game_object) {
     return false;  // not found
   }
 
+  found_object->get()->remove_all_components();
   game_objects_.erase(found_object);
 
   return true;
+}
+
+void Scene::cleanup_destroyed_game_objects() {
+  for (auto& obj : game_objects_) {
+    if (obj->marked_for_deletion()) {
+      obj->remove_all_components();
+    }
+  }
+
+  std::erase_if(game_objects_, [](const std::unique_ptr<GameObject>& obj) {
+    return obj->marked_for_deletion();
+  });
 }
 
 std::optional<std::reference_wrapper<Camera>> Scene::main_camera() const {


### PR DESCRIPTION
This PR fixes item deletion. Before it never detached all its components which leads to spooky behavior and a lot of segmentation faults. Now we check properly before destroying. I also added a shortcut to cleanup all marked objects. Ideally we could do something like this to reset a level:

```cpp
void SwampScene::load(Scene& scene) {
    // ...
}

void SwampScene::unload(Scene& scene) {
    for (auto& game_object_ref : scene.game_objects()) {
        auto& game_object = game_object_ref.get();
        if (!game_object.dont_destroy_on_load()) {
            game_object.mark_for_deletion();
        }
    }

    scene.cleanup_destroyed_game_objects();
}

Scene& SwampScene::setup() {
    const Engine& engine = Engine::instance();
    Scene& scene = engine.services->get_service<SceneService>().get().add_scene(SCENE_NAME);

    scene.on_run([&audio_service](Scene& scene) {
        SwampScene::load(scene);
        // ...
    });

    scene.on_stop([&audio_service](Scene& scene) {
        SwampScene::unload(scene);
       //  ...
    });

    return scene;
}
```