### PR TITLE
fix (scene): safe deletion

### DIFF
--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -35,7 +35,6 @@ class GameObject {
 
  public:
   explicit GameObject(Scene& scene);
-  virtual ~GameObject();
 
   GameObject(const GameObject&) = delete;
   GameObject& operator=(const GameObject&) = delete;

--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -35,6 +35,7 @@ class GameObject {
 
  public:
   explicit GameObject(Scene& scene);
+  virtual ~GameObject() = default;
 
   GameObject(const GameObject&) = delete;
   GameObject& operator=(const GameObject&) = delete;

--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -12,16 +12,6 @@
 GameObject::GameObject(Scene& scene)
     : id_(uuid::generate_uuid_v4()), scene_(scene) {}
 
-GameObject::~GameObject() {
-  if (parent_.has_value()) {
-    parent_->get().remove_child(*this);
-  }
-
-  for (auto child : children_) {
-    scene_.get().remove_game_object(child);
-  }
-}
-
 std::string GameObject::id() const noexcept { return id_; }
 
 GameObject& GameObject::name(const std::string& name) {

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -279,17 +279,37 @@ bool Scene::remove_game_object(GameObject& game_object) {
 
   found_object->get()->mark_for_deletion();
 
-  for (auto& child_ref : found_object->get()->children()) {
-    child_ref.get().mark_for_deletion();
-  }
-
   return true;
 }
 
 void Scene::cleanup_destroyed_game_objects() {
+  /// Recursively mark and detach all children and components of the game object
+  /// for deletion. This ensures that when a parent game object is deleted,
+  /// all its children and their components are also properly marked and
+  /// detached. We can't do this in loop as we would modify the children vector
+  /// while iterating it.
+  auto mark_and_detach_recursive = [](GameObject& obj,
+                                      auto& mark_and_detach_ref) -> void {
+    std::vector<std::reference_wrapper<GameObject>> to_detach;
+
+    for (auto& child_ref : obj.children()) {
+      auto& child = child_ref.get();
+      mark_and_detach_ref(child, mark_and_detach_ref);
+
+      child.mark_for_deletion();
+      to_detach.push_back(child);
+    }
+
+    for (auto& child : to_detach) {
+      obj.remove_child(child);
+    }
+
+    obj.remove_all_components();
+  };
+
   for (auto& obj : game_objects_) {
     if (obj->marked_for_deletion()) {
-      obj->remove_all_components();
+      mark_and_detach_recursive(*obj, mark_and_detach_recursive);
     }
   }
 

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -269,16 +269,19 @@ std::unique_ptr<GameObject> Scene::extract_game_object(
 }
 
 bool Scene::remove_game_object(GameObject& game_object) {
-  auto found_object = std::find_if(game_objects_.begin(), game_objects_.end(),
-                                   [&game_object](const auto& param) {
-                                     return param.get() == &game_object;
-                                   });
+  auto found_object = std::find_if(
+      game_objects_.begin(), game_objects_.end(),
+      [&game_object](const auto& obj) { return obj.get() == &game_object; });
 
   if (found_object == game_objects_.end()) {
-    return false;  // not found
+    return false;
   }
 
   found_object->get()->mark_for_deletion();
+
+  for (auto& child_ref : found_object->get()->children()) {
+    child_ref.get().mark_for_deletion();
+  }
 
   return true;
 }

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -278,7 +278,6 @@ bool Scene::remove_game_object(GameObject& game_object) {
     return false;  // not found
   }
 
-  found_object->get()->remove_all_components();
   found_object->get()->mark_for_deletion();
 
   return true;

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -288,28 +288,23 @@ void Scene::cleanup_destroyed_game_objects() {
   /// all its children and their components are also properly marked and
   /// detached. We can't do this in loop as we would modify the children vector
   /// while iterating it.
-  auto mark_and_detach_recursive = [](GameObject& obj,
-                                      auto& mark_and_detach_ref) -> void {
-    std::vector<std::reference_wrapper<GameObject>> to_detach;
-
+  auto mark_detach_recursive = [](GameObject& obj, auto& self) -> void {
+    std::vector<std::reference_wrapper<GameObject>> children_to_process;
     for (auto& child_ref : obj.children()) {
-      auto& child = child_ref.get();
-      mark_and_detach_ref(child, mark_and_detach_ref);
-
-      child.mark_for_deletion();
-      to_detach.push_back(child);
+      children_to_process.push_back(child_ref.get());
     }
 
-    for (auto& child : to_detach) {
-      obj.remove_child(child);
+    for (auto& child : children_to_process) {
+      obj.remove_child(child.get());
+      self(child.get(), self);
+      child.get().mark_for_deletion();
     }
-
-    obj.remove_all_components();
   };
 
   for (auto& obj : game_objects_) {
     if (obj->marked_for_deletion()) {
-      mark_and_detach_recursive(*obj, mark_and_detach_recursive);
+      mark_detach_recursive(*obj, mark_detach_recursive);
+      obj->remove_all_components();
     }
   }
 

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -295,8 +295,8 @@ void Scene::cleanup_destroyed_game_objects() {
     }
 
     for (auto& child : children_to_process) {
-      obj.remove_child(child.get());
-      self(child.get(), self);
+      self(child.get(), self);        // Recurse first
+      obj.remove_child(child.get());  // Then detach
       child.get().mark_for_deletion();
     }
   };

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -279,7 +279,7 @@ bool Scene::remove_game_object(GameObject& game_object) {
   }
 
   found_object->get()->remove_all_components();
-  game_objects_.erase(found_object);
+  found_object->get()->mark_for_deletion();
 
   return true;
 }

--- a/tests/engine/scenes/scene.cpp
+++ b/tests/engine/scenes/scene.cpp
@@ -95,6 +95,7 @@ TEST_CASE("RemoveGameObject_RemovesRightGameObjectFromScene", "[Scene]") {
 
   // act
   scene.remove_game_object(obj1);
+  scene.cleanup_destroyed_game_objects();
 
   // assert
   REQUIRE(scene.game_objects().size() == 1);
@@ -116,6 +117,7 @@ TEST_CASE("RemoveGameObject_RemovesGameObjectWithAllChildObjects", "[Scene]") {
 
   // act
   scene.remove_game_object(parent);
+  scene.cleanup_destroyed_game_objects();
 
   // assert
   REQUIRE(scene.game_objects().empty());


### PR DESCRIPTION
I realized that the current public removal function is not safe anymore due to it removing things hard from the scene. Now it simply marks it as removed to avoid hard things.