### PR TITLE
feat (scene): add mark for stopping to avoid hard stop

### DIFF
--- a/include/engine/public/scene.h
+++ b/include/engine/public/scene.h
@@ -11,7 +11,10 @@ class Scene {
  private:
   int stop_event_listener_id_;
   const std::string name_;
+
+  bool is_stopping_;
   bool is_running_;
+
   float time_scale_;
 
   std::vector<std::unique_ptr<GameObject>> game_objects_;
@@ -37,6 +40,9 @@ class Scene {
   void on_destroy(listener_function_t&& listener);
 
   void stop();
+
+  bool marked_for_stopping() const;
+  void mark_for_stopping() noexcept;
 
   Scene& time_scale(float modifier);
   [[nodiscard]] float time_scale() const;

--- a/src/public/scene.cpp
+++ b/src/public/scene.cpp
@@ -143,6 +143,8 @@ void Scene::game_loop() {  // NOLINT [readability-make-member-function-const]
         if (game_object.marked_for_deletion()) {
           marked_for_deletion.push_back(game_object);
         }
+
+        if (is_stopping_ || !is_running_) break;
       }
 
       rendering_service.draw(layered_renderables, *this);
@@ -150,6 +152,11 @@ void Scene::game_loop() {  // NOLINT [readability-make-member-function-const]
       // 5. cleanup marked for deletion game objects AFTER rendering
       cleanup_destroyed_game_objects();
     });
+
+    // 6. check for stop condition
+    if (marked_for_stopping()) {
+      is_running_ = false;
+    }
   }
 }
 
@@ -175,6 +182,10 @@ void Scene::stop() {
       Engine::instance().services->get_service<SystemService>().get();
   system_service.remove_listener(EVENT_QUIT, stop_event_listener_id_);
 }
+
+bool Scene::marked_for_stopping() const { return is_stopping_; }
+
+void Scene::mark_for_stopping() noexcept { is_stopping_ = true; }
 
 Scene& Scene::time_scale(float modifier) {
   time_scale_ = modifier;


### PR DESCRIPTION
Stopping a scene with the normal `stop` forces a hard stop. In case of our new deletion idea, all items in scene get deleted and loaded again, this can't stop like that. If we do that then it means that we destroy our objects in the current loop. So here is a safe new method where you can mark a scene for stopping. That way all loops will run its course, but quit while the objects still exist