### PR TITLE
feat (animator): add non-interuptable property

### DIFF
--- a/include/engine/public/components/animator.h
+++ b/include/engine/public/components/animator.h
@@ -16,6 +16,7 @@ class Animator : public Component {
 
   bool is_playing_;
   bool is_looping_;
+  bool is_non_interruptible_{false};
 
   [[nodiscard]] int calculate_next_frame_index(int intervals_advanced) const;
   void update_sprite_texture(int new_frame_index);
@@ -29,6 +30,9 @@ class Animator : public Component {
   void pause();
   void reset();
   [[nodiscard]] bool is_playing() const noexcept;
+
+  [[nodiscard]] bool is_non_interruptible() const noexcept;
+  void is_non_interruptible(bool value) noexcept;
 
   // Component overrides
   void update(float dt_seconds) override;

--- a/src/public/animator.cpp
+++ b/src/public/animator.cpp
@@ -47,6 +47,13 @@ void Animator::reset() {
 
 bool Animator::is_playing() const noexcept { return is_playing_; }
 
+bool Animator::is_non_interruptible() const noexcept {
+  return is_non_interruptible_;
+}
+void Animator::is_non_interruptible(bool value) noexcept {
+  is_non_interruptible_ = value;
+}
+
 /**
  * So the C++ modulo works crappy with negative numbers.
  * Imagine current_frame_index = 2, frame_count = 5, frames_advanced = -3
@@ -126,6 +133,7 @@ void Animator::update(float dt) {
 
     if (!is_looping_ && current_texture_index_ == frames_.size() - 1) {
       is_playing_ = false;
+      if (is_non_interruptible_) is_non_interruptible_ = false;
     }
   }
 }


### PR DESCRIPTION
When working with player movement I noticed that hitting is not a part of movement, that logic is somewhere else. However, movement does update the texture on each frame to ensure that its the right idle. Hence I figured to add a property to the animator so we can flag an animation as "non-interruptible"/"locked". It automatically opens it when the animation is finished. 

The idea is not that the animator manages this, but the game developer. You can flag an animation non interruptable (like hitting) and check in certain places if a non-interruptable is playing (movement).