### PR TITLE
feat (gameobject): add method to fetch behavior

### DIFF
--- a/include/engine/public/gameObject.h
+++ b/include/engine/public/gameObject.h
@@ -115,6 +115,23 @@ class GameObject {
                                                   filtered.end());
   }
 
+  /** Get the first Behavior of type B attached to this GameObject's
+      BehaviorScript components. */
+  template <IsComponent BS, typename B>
+  [[nodiscard]] std::optional<std::reference_wrapper<B>> get_script()
+      const noexcept {
+    auto scripts = get_components<BS>();
+
+    for (const auto& script : scripts) {
+      if (auto& behavior = script.get().behavior();
+          dynamic_cast<B*>(&behavior)) {
+        return std::ref(static_cast<B&>(behavior));
+      }
+    }
+
+    return std::nullopt;
+  }
+
   /** Get all components (non-templated) attached to this GameObject. */
   [[nodiscard]] std::vector<std::reference_wrapper<Component>>
   get_components_all() const;


### PR DESCRIPTION
In the game we quite frequently need to get a specific behavior. Its not a big or difficult for loop, but its repetitive. This adds a simple method to get a script. It searches in the first type for the second:

`auto controller_opt = other_gameobject.get_script<BehaviorScript, PlayerController>();`

Ideally I wanted to remove the passing of `Behaviorscript` as a type but that creates a lot of conflicts due to class forwarding. This is the easier and modular fix as we could search for any type of script if we introduce more