### PR TITLE
fix (gameobject): set transform parent on set parent

### DIFF
--- a/src/public/gameObject.cpp
+++ b/src/public/gameObject.cpp
@@ -109,6 +109,8 @@ GameObject& GameObject::parent(GameObject& parent) {
     parent.add_child(*this);
   }
 
+  transform_.parent(std::ref(parent.transform()));
+
   return *this;
 }
 


### PR DESCRIPTION
This PR fixes the problem that gameobjects which get a parent don't always take their transform parent causing the wrong location display. An example was picking and dropping a weapon in quick succession, the speed of it could cause it not being set. Now its always enforced as we know a parent is present.