### PR TITLE
feat (multiplayer): register IP of host

### DIFF
--- a/include/engine/network/client.h
+++ b/include/engine/network/client.h
@@ -63,8 +63,11 @@ public:
 
     [[nodiscard]] std::string get_uuid() const noexcept;
 
+    [[nodiscard]] std::string get_host_ip() const noexcept;
+
 private:
     std::string local_uuid_;
+    std::string host_ip_{"0.0.0.0"};
     std::reference_wrapper<Router> router_;
     ENetPeer* server_peer_{nullptr};
     ENetHost* client_{nullptr};

--- a/include/engine/network/host.h
+++ b/include/engine/network/host.h
@@ -75,6 +75,8 @@ public:
      */
     [[nodiscard]] int get_client_amount() const noexcept;
 
+    [[nodiscard]] std::string get_ip() const noexcept;
+
     /**
      * @brief Sets the server port. Only effective before start_server().
      */
@@ -98,6 +100,7 @@ private:
     int max_clients_{0};
     ConnectionState connection_state_{ConnectionState::NONE};
 
+    std::string ip_;
     std::string local_uuid_;
     std::reference_wrapper<Router> router_;
 

--- a/include/engine/network/multiplayer_service.h
+++ b/include/engine/network/multiplayer_service.h
@@ -115,6 +115,8 @@ public:
     void set_connection_port(int port) noexcept;
     [[nodiscard]] int get_connection_port() const noexcept;
 
+    [[nodiscard]] std::string get_host_ip() const;
+
 private:
     std::unique_ptr<Router> router_{nullptr};
     std::unique_ptr<Client> client_{nullptr};

--- a/src/network/client.cpp
+++ b/src/network/client.cpp
@@ -153,6 +153,10 @@ void Client::connect(const std::string& host_ip, int connection_port)
     if (server_peer_ == nullptr)
         throw std::runtime_error("ENet could not create a peer for connection attempt.");
 
+        
+    char ip[32];
+    enet_address_get_host_ip(&server_peer_->address, ip, sizeof(ip));
+    host_ip_ = ip;
     // A timed connection attempt could be implemented here.
 }
 
@@ -179,6 +183,11 @@ ConnectionState Client::get_connection_state() const noexcept
 std::string Client::get_uuid() const noexcept
 {
     return local_uuid_;
+}
+
+std::string Client::get_host_ip() const noexcept
+{
+    return host_ip_;
 }
 
 void Client::register_on_connect_handler() noexcept

--- a/src/network/host.cpp
+++ b/src/network/host.cpp
@@ -33,6 +33,28 @@ Host::~Host() noexcept
 
 void Host::start_server()
 {
+    // Find local IP address
+    ENetAddress addr{};
+    addr.host = ENET_HOST_ANY;
+    
+    ENetHost* host = enet_host_create(&addr, 1, 2, 0, 0);
+    if (!host)
+        throw std::runtime_error("Failed to create ENet host");
+
+    ENetAddress remote{};
+    enet_address_set_host(&remote, "8.8.8.8");
+    remote.port = 1;
+    enet_socket_connect(host->socket, &remote);
+
+    ENetAddress local{};
+    enet_socket_get_address(host->socket, &local);
+    
+    char ip[32];
+    enet_address_get_host_ip(&local, ip, sizeof(ip));
+    ip_ = ip;
+    enet_host_destroy(host);
+
+    // Start server
     ENetAddress address{};
     address.host = ENET_HOST_ANY;
     address.port = connection_port_;
@@ -250,6 +272,11 @@ void Host::set_max_clients(int amount) noexcept
 int Host::get_client_amount() const noexcept
 {
     return static_cast<int>(clients_.size());
+}
+
+std::string Host::get_ip() const noexcept
+{
+    return ip_;
 }
 
 void Host::set_connection_port(int port) noexcept

--- a/src/network/multiplayer_service.cpp
+++ b/src/network/multiplayer_service.cpp
@@ -200,3 +200,16 @@ int MultiplayerService::get_connection_port() const noexcept
 {
     return connection_port_;
 }
+
+std::string MultiplayerService::get_host_ip() const
+{
+    if (host_) {
+        return host_->get_ip();
+    }
+    else if (client_) {
+        return client_->get_host_ip();
+    }
+    else {
+        throw std::runtime_error("Cannot get host ip: must be a host or connected client first.");
+    }
+}


### PR DESCRIPTION
When host starts server, it registers its own IP address. When client connects, it registers the IP it used to connect.