### PR TITLE
fix (aicontroller): hover on no path found

### DIFF
--- a/src/public/components/ai/ai_controller.cpp
+++ b/src/public/components/ai/ai_controller.cpp
@@ -153,7 +153,13 @@ void AIController::try_traverse_graph(Transform& source, Transform& target,
     path_ = std::move(pathfinding.get_path());
   }
 
-  if (path_.empty()) return;
+  if (path_.empty()) {
+    if (rigidbody_.has_value()) {
+      rigidbody_->get().velocity(Vector3(0.0f, 0.0f, 0.0f));
+    }
+
+    return;
+  }
 
   auto& next_node = path_.front().get();
 


### PR DESCRIPTION
This PR fixes the bug where an ai agent with a rigidibody keeps its velocity on losing its path. That way it would keep flying in that direction which was often off the platform.