### PR TITLE
fix (multiplayer): reset host or client upon disconnecting

### DIFF
--- a/src/network/multiplayer_service.cpp
+++ b/src/network/multiplayer_service.cpp
@@ -137,9 +137,11 @@ void MultiplayerService::disconnect()
 {
     if (host_) {
         host_->disconnect();
+        host_.reset();
     }
     else if (client_) {
         client_->disconnect();
+        client_.reset();
     }
     else {
         throw std::runtime_error("Cannot disconnect: service is neither client nor host.");


### PR DESCRIPTION
Reset the host or client, depending on what you are.

This fixes two bugs that are currently in the game:
- When you create a game as a host and leave it, you cannot join a game
- When you leave a game as a client and want to rejoin, you couldn't

Do note that this visualized a different bug in the game that has nothing to do with this fix, so it doesn't look 'fixed' after this PR, but that's a different issue