### PR TITLE
fix (multiplayer): add disconnect callback

### DIFF
--- a/include/engine/network/multiplayer_service.h
+++ b/include/engine/network/multiplayer_service.h
@@ -1,21 +1,17 @@
 #pragma once
 
-#include <memory>
-#include <functional>
-#include <string>
 #include <enet/enet.h>
-
 #include <engine/core/iEngineService.h>
 #include <engine/network/client.h>
+#include <engine/network/connection_state.h>
 #include <engine/network/host.h>
 #include <engine/network/router.h>
-#include <engine/network/connection_state.h>
 
-enum class PeerType : uint16_t {
-    HOST,
-    CLIENT,
-    NONE
-};
+#include <functional>
+#include <memory>
+#include <string>
+
+enum class PeerType : uint16_t { HOST, CLIENT, NONE };
 
 /**
  * @class MultiplayerService
@@ -27,101 +23,104 @@ enum class PeerType : uint16_t {
  * It wraps ENet initialization and manages both Host and Client instances.
  */
 class MultiplayerService : public IEngineService {
-public:
-    static constexpr int16_t default_connection_port = 1024;
-    static constexpr int16_t default_max_clients = 4;
+ public:
+  static constexpr int16_t default_connection_port = 1024;
+  static constexpr int16_t default_max_clients = 4;
 
-    /**
-     * @brief Initializes ENet and prepares the internal Router.
-     * @throws std::runtime_error if ENet initialization fails.
-     */
-    MultiplayerService();
+  /**
+   * @brief Initializes ENet and prepares the internal Router.
+   * @throws std::runtime_error if ENet initialization fails.
+   */
+  MultiplayerService();
 
-    /**
-     * @brief Registers a callback handler for a specific message type.
-     * @param type Message type
-     * @param handler Function invoked on message reception
-     */
-    void register_handler(MessageType type,
-                          const std::function<void(const Message&)>& handler);
+  /**
+   * @brief Registers a callback handler for a specific message type.
+   * @param type Message type
+   * @param handler Function invoked on message reception
+   */
+  void register_handler(MessageType type,
+                        const std::function<void(const Message&)>& handler);
 
-    /**
-     * @brief Removes a previously registered handler for a message type.
-     */
-    void unregister_handler(MessageType type);
+  /**
+   * @brief Removes a previously registered handler for a message type.
+   */
+  void unregister_handler(MessageType type);
 
-    /**
-     * @brief Switches the service into host-mode. Invalidates any client instance.
-     * @throws std::runtime_error if the current client has an active connection.
-     */
-    void set_host();
+  /**
+   * @brief Switches the service into host-mode. Invalidates any client
+   * instance.
+   * @throws std::runtime_error if the current client has an active connection.
+   */
+  void set_host();
 
-    /**
-     * @brief Switches the service into client-mode. Invalidates any host instance.
-     * @throws std::runtime_error if the current host has active clients or running server.
-     */
-    void set_client();
+  /**
+   * @brief Switches the service into client-mode. Invalidates any host
+   * instance.
+   * @throws std::runtime_error if the current host has active clients or
+   * running server.
+   */
+  void set_client();
 
-    /**
-     * @brief Returns the current peer type (host, client, or none).
-     * @return PeerType indicating the current mode of operation.
-     */
-    PeerType get_peer_type() const;
+  /**
+   * @brief Returns the current peer type (host, client, or none).
+   * @return PeerType indicating the current mode of operation.
+   */
+  PeerType get_peer_type() const;
 
-    /**
-     * @brief Polls the network. Behavior depends on host/client mode.
-     */
-    void poll();
+  /**
+   * @brief Polls the network. Behavior depends on host/client mode.
+   */
+  void poll();
 
-    /**
-     * @brief Sends a message. Host broadcasts; client sends to server.
-     */
-    void send(const Message& message);
+  /**
+   * @brief Sends a message. Host broadcasts; client sends to server.
+   */
+  void send(const Message& message);
 
-    /**
-     * @brief Sends a message to a specific connected client (host mode only).
-     * @param uuid Target client's UUID.
-     * @param message Message to send.
-     */
-    void send_to_peer_via_uuid(const std::string& uuid, const Message& message);
+  /**
+   * @brief Sends a message to a specific connected client (host mode only).
+   * @param uuid Target client's UUID.
+   * @param message Message to send.
+   */
+  void send_to_peer_via_uuid(const std::string& uuid, const Message& message);
 
-    /**
-     * @brief Starts the host server. Only valid in host-mode.
-     * @throws std::runtime_error if called while acting as client.
-     */
-    void start_server();
+  /**
+   * @brief Starts the host server. Only valid in host-mode.
+   * @throws std::runtime_error if called while acting as client.
+   */
+  void start_server();
 
-    /**
-     * @brief Connect to a remote server. Only valid in client-mode.
-     */
-    void connect(const std::string& address);
+  /**
+   * @brief Connect to a remote server. Only valid in client-mode.
+   */
+  void connect(const std::string& address);
 
-    /**
-     * @brief Disconnect the active host or client gracefully.
-     * @throws std::runtime_error if not acting as host or client.
-     */
-    void disconnect();
+  /**
+   * @brief Disconnect the active host or client gracefully.
+   * @throws std::runtime_error if not acting as host or client.
+   */
+  void disconnect(std::function<void()> on_disconnected = nullptr);
 
-    /**
-     * @brief Returns connection state of the current mode.
-     */
-    [[nodiscard]] ConnectionState get_connection_state() const noexcept;
+  /**
+   * @brief Returns connection state of the current mode.
+   */
+  [[nodiscard]] ConnectionState get_connection_state() const noexcept;
 
-    [[nodiscard]] std::string get_uuid() const;
+  [[nodiscard]] std::string get_uuid() const;
 
-    void set_max_clients(int amount) noexcept;
-    [[nodiscard]] int get_client_amount() const noexcept;
+  void set_max_clients(int amount) noexcept;
+  [[nodiscard]] int get_client_amount() const noexcept;
 
-    void set_connection_port(int port) noexcept;
-    [[nodiscard]] int get_connection_port() const noexcept;
+  void set_connection_port(int port) noexcept;
+  [[nodiscard]] int get_connection_port() const noexcept;
 
-    [[nodiscard]] std::string get_host_ip() const;
+  [[nodiscard]] std::string get_host_ip() const;
 
-private:
-    std::unique_ptr<Router> router_{nullptr};
-    std::unique_ptr<Client> client_{nullptr};
-    std::unique_ptr<Host> host_{nullptr};
+ private:
+  std::unique_ptr<Router> router_{nullptr};
+  std::unique_ptr<Client> client_{nullptr};
+  std::unique_ptr<Host> host_{nullptr};
 
-    int16_t connection_port_{default_connection_port};
-    int16_t max_clients_{default_max_clients};
+  int16_t connection_port_{default_connection_port};
+  int16_t max_clients_{default_max_clients};
 };

--- a/src/network/multiplayer_service.cpp
+++ b/src/network/multiplayer_service.cpp
@@ -1,217 +1,197 @@
 #include <engine/network/multiplayer_service.h>
 #include <engine/network/snapshot.h>
-#include <chrono>
 
+#include <chrono>
 #include <stdexcept>
 
-MultiplayerService::MultiplayerService()
-{
-    if (enet_initialize() != 0) { // 0 on succes, < 0 on failure
-        throw std::runtime_error("Failed to initialize ENet.");
-    }
+MultiplayerService::MultiplayerService() {
+  if (enet_initialize() != 0) {  // 0 on succes, < 0 on failure
+    throw std::runtime_error("Failed to initialize ENet.");
+  }
 
-    atexit(enet_deinitialize);
+  atexit(enet_deinitialize);
 
-    router_ = std::make_unique<Router>();
+  router_ = std::make_unique<Router>();
 }
 
 void MultiplayerService::register_handler(
-    MessageType type,
-    const std::function<void(const Message&)>& handler)
-{
-    router_->register_handler(type, handler);
+    MessageType type, const std::function<void(const Message&)>& handler) {
+  router_->register_handler(type, handler);
 }
 
-void MultiplayerService::unregister_handler(MessageType type)
-{
-    router_->unregister_handler(type);
+void MultiplayerService::unregister_handler(MessageType type) {
+  router_->unregister_handler(type);
 }
 
-void MultiplayerService::set_host()
-{
-    // If currently client, ensure it isn't connected
-    if (client_) {
-        const auto state = client_->get_connection_state();
-        if (state != ConnectionState::DISCONNECTED &&
-            state != ConnectionState::NONE)
-        {
-            throw std::runtime_error("Cannot switch to host mode: client still connected.");
-        }
-
-        client_.reset();
+void MultiplayerService::set_host() {
+  // If currently client, ensure it isn't connected
+  if (client_) {
+    const auto state = client_->get_connection_state();
+    if (state != ConnectionState::DISCONNECTED &&
+        state != ConnectionState::NONE) {
+      throw std::runtime_error(
+          "Cannot switch to host mode: client still connected.");
     }
 
-    host_ = std::make_unique<Host>(std::ref(*router_), connection_port_, max_clients_);
+    client_.reset();
+  }
+
+  host_ = std::make_unique<Host>(std::ref(*router_), connection_port_,
+                                 max_clients_);
 }
 
-void MultiplayerService::set_client()
-{
-    // If currently host, ensure server isn't running
-    if (host_) {
-        const auto state = host_->get_connection_state();
-        if (state != ConnectionState::DISCONNECTED &&
-            state != ConnectionState::NONE)
-        {
-            throw std::runtime_error("Cannot switch to client mode: host server still active.");
-        }
-
-        host_.reset();
+void MultiplayerService::set_client() {
+  // If currently host, ensure server isn't running
+  if (host_) {
+    const auto state = host_->get_connection_state();
+    if (state != ConnectionState::DISCONNECTED &&
+        state != ConnectionState::NONE) {
+      throw std::runtime_error(
+          "Cannot switch to client mode: host server still active.");
     }
 
-    client_ = std::make_unique<Client>(std::ref(*router_));
+    host_.reset();
+  }
+
+  client_ = std::make_unique<Client>(std::ref(*router_));
 }
 
-PeerType MultiplayerService::get_peer_type() const
-{
-    if (host_) {
-        return PeerType::HOST;
-    }
-    else if (client_) {
-        return PeerType::CLIENT;
-    }
-    else {
-        return PeerType::NONE;
-    }
+PeerType MultiplayerService::get_peer_type() const {
+  if (host_) {
+    return PeerType::HOST;
+  } else if (client_) {
+    return PeerType::CLIENT;
+  } else {
+    return PeerType::NONE;
+  }
 }
 
-void MultiplayerService::poll()
-{
-    if (host_) {
-        host_->poll();
-        host_->sync();
-    }
-    else if (client_) {
-        client_->poll();
-    }
+void MultiplayerService::poll() {
+  if (host_) {
+    host_->poll();
+    host_->sync();
+  } else if (client_) {
+    client_->poll();
+  }
 }
 
-void MultiplayerService::send(const Message& message)
-{
-    if (host_) {
-        host_->broadcast(message);
-    }
-    else if (client_) {
-        client_->send(message);
-    }
-    else {
-        throw std::runtime_error("Cannot send: service is neither client nor host.");
-    }
+void MultiplayerService::send(const Message& message) {
+  if (host_) {
+    host_->broadcast(message);
+  } else if (client_) {
+    client_->send(message);
+  } else {
+    throw std::runtime_error(
+        "Cannot send: service is neither client nor host.");
+  }
 }
 
-void MultiplayerService::send_to_peer_via_uuid(const std::string& uuid, const Message& message)
-{
-    if (!host_) {
-        throw std::runtime_error("send_to_peer_via_uuid is only available in host mode.");
-    }
+void MultiplayerService::send_to_peer_via_uuid(const std::string& uuid,
+                                               const Message& message) {
+  if (!host_) {
+    throw std::runtime_error(
+        "send_to_peer_via_uuid is only available in host mode.");
+  }
 
-    host_->send_to_peer_via_uuid(uuid, message);
+  host_->send_to_peer_via_uuid(uuid, message);
 }
 
-void MultiplayerService::start_server()
-{
-    if (client_) {
-        throw std::runtime_error("Cannot start server while acting as client.");
-    }
+void MultiplayerService::start_server() {
+  if (client_) {
+    throw std::runtime_error("Cannot start server while acting as client.");
+  }
 
-    if (!host_) {
-        throw std::runtime_error("Host instance not initialized. Call set_host() first.");
-    }
+  if (!host_) {
+    throw std::runtime_error(
+        "Host instance not initialized. Call set_host() first.");
+  }
 
-    host_->start_server();
+  host_->start_server();
 }
 
-void MultiplayerService::connect(const std::string& address)
-{
-    if (host_) {
-        throw std::runtime_error("Cannot connect while acting as host.");
-    }
+void MultiplayerService::connect(const std::string& address) {
+  if (host_) {
+    throw std::runtime_error("Cannot connect while acting as host.");
+  }
 
-    if (!client_) {
-        throw std::runtime_error("Client instance not initialized. Call set_client() first.");
-    }
+  if (!client_) {
+    throw std::runtime_error(
+        "Client instance not initialized. Call set_client() first.");
+  }
 
-    client_->connect(address, connection_port_);
+  client_->connect(address, connection_port_);
 }
 
-void MultiplayerService::disconnect()
-{
-    if (host_) {
-        host_->disconnect();
-        host_.reset();
-    }
-    else if (client_) {
-        client_->disconnect();
-        client_.reset();
-    }
-    else {
-        throw std::runtime_error("Cannot disconnect: service is neither client nor host.");
-    }
+void MultiplayerService::disconnect(std::function<void()> on_disconnected) {
+  if (host_)
+    host_->disconnect();
+  else if (client_)
+    client_->disconnect();
+
+  if (on_disconnected) on_disconnected();
+
+  if (host_)
+    host_.reset();
+  else if (client_)
+    client_.reset();
+  else
+    throw std::runtime_error(
+        "Cannot disconnect: service is neither client nor host.");
 }
 
-ConnectionState MultiplayerService::get_connection_state() const noexcept
-{
-    if (host_) {
-        return host_->get_connection_state();
-    }
-    else if (client_) {
-        return client_->get_connection_state();
-    }
-    else {
-        return ConnectionState::NONE;
-    }
+ConnectionState MultiplayerService::get_connection_state() const noexcept {
+  if (host_) {
+    return host_->get_connection_state();
+  } else if (client_) {
+    return client_->get_connection_state();
+  } else {
+    return ConnectionState::NONE;
+  }
 }
 
-std::string MultiplayerService::get_uuid() const
-{
-    if (host_) {
-        return host_->get_uuid();
-    }
-    else if (client_) {
-        return client_->get_uuid();
-    }
-    else {
-        throw std::runtime_error("Cannot get uuid: must be a host or connected client first.");
-    }
+std::string MultiplayerService::get_uuid() const {
+  if (host_) {
+    return host_->get_uuid();
+  } else if (client_) {
+    return client_->get_uuid();
+  } else {
+    throw std::runtime_error(
+        "Cannot get uuid: must be a host or connected client first.");
+  }
 }
 
-void MultiplayerService::set_max_clients(int amount) noexcept
-{
-    max_clients_ = amount;
-    if (host_) {
-        host_->set_max_clients(amount);
-    }
+void MultiplayerService::set_max_clients(int amount) noexcept {
+  max_clients_ = amount;
+  if (host_) {
+    host_->set_max_clients(amount);
+  }
 }
 
-int MultiplayerService::get_client_amount() const noexcept
-{
-    if (host_){
-        return host_->get_client_amount();
-    }
-    return 0;
+int MultiplayerService::get_client_amount() const noexcept {
+  if (host_) {
+    return host_->get_client_amount();
+  }
+  return 0;
 }
 
-void MultiplayerService::set_connection_port(int port) noexcept
-{
-    connection_port_ = port;
-    if (host_) {
-        host_->set_connection_port(port);
-    }
+void MultiplayerService::set_connection_port(int port) noexcept {
+  connection_port_ = port;
+  if (host_) {
+    host_->set_connection_port(port);
+  }
 }
 
-int MultiplayerService::get_connection_port() const noexcept
-{
-    return connection_port_;
+int MultiplayerService::get_connection_port() const noexcept {
+  return connection_port_;
 }
 
-std::string MultiplayerService::get_host_ip() const
-{
-    if (host_) {
-        return host_->get_ip();
-    }
-    else if (client_) {
-        return client_->get_host_ip();
-    }
-    else {
-        throw std::runtime_error("Cannot get host ip: must be a host or connected client first.");
-    }
+std::string MultiplayerService::get_host_ip() const {
+  if (host_) {
+    return host_->get_ip();
+  } else if (client_) {
+    return client_->get_host_ip();
+  } else {
+    throw std::runtime_error(
+        "Cannot get host ip: must be a host or connected client first.");
+  }
 }


### PR DESCRIPTION
This PR adds a callback when a user disconnects. It executes between the disconnect and reset of the pointer. That way the host/peer disconnect is executed, then our functions and finally the reset of the pointer.